### PR TITLE
[CLOUD-2081] remove hawular agent artifact

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -209,8 +209,6 @@ artifacts:
       md5: 2f74acc3efc68e3781b7004f5a683fdc
     - path: oauth-20100527.jar
       md5: 91c7c70579f95b7ddee95b2143a49b41
-    - path: hawkular-javaagent-1.0.0.CR5-redhat-1-shaded.jar
-      md5: f5d3e0220e10c706ef86af84771cf74e
 run:
       user: 185
       cmd:


### PR DESCRIPTION
The hawkular agent artifact is now included in the cct os-hawkular-java module

Signed-off-by: Paul Gier <pgier@redhat.com>

https://issues.jboss.org/browse/CLOUD-2081

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
