### PR TITLE
Bump the version of the sso72-openshift image for the -dev branch

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72-openshift"
 description: "Red Hat Single Sign-On 7.2 OpenShift container image"
-version: "1.0"
+version: "1.1"
 from: "redhat-sso-7/sso72:latest"
 labels:
     - name: "io.k8s.description"


### PR DESCRIPTION
Since we know have ```sso72``` branch holding the ```1.0``` image version, bump the version in the -dev branch to ```1.1```

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
