### PR TITLE
[Post RH-SSO 7.2.0.GA release cleanup] Re-apply the fix for CLOUD-2314. Point cct_module ref back to 'master'

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -20,12 +20,6 @@ envs:
       value: "jee"
     - name: "JBOSS_MODULES_SYSTEM_PKGS"
       value: "org.jboss.logmanager,jdk.nashorn.api"
-    - name: "AB_JOLOKIA_PASSWORD_RANDOM"
-      value: "true"
-    - name: AB_JOLOKIA_AUTH_OPENSHIFT
-      value: "true"
-    - name: AB_JOLOKIA_HTTPS
-      value: "true"
     - name: "DEFAULT_ADMIN_USERNAME"
       value: "eapadmin"
     - name: "JAVA_OPTS_APPEND"
@@ -61,42 +55,6 @@ envs:
     - name: "SSO_TRUSTSTORE_SECRET"
       example: "truststore-secret"
       description: "The name of the secret containing the truststore file. Used for volume secretName"
-    - name: AB_JOLOKIA_OFF
-      description: If set disables activation of Joloka (i.e. echos an empty value). By default, Jolokia is enabled.
-      example: "true"
-    - name: AB_JOLOKIA_CONFIG
-      description: If set uses this file (including path) as Jolokia JVM agent properties (as described in Jolokia's link:https://www.jolokia.org/reference/html/agents.html#agents-jvm[reference manual]). If not set, the `/opt/jolokia/etc/jolokia.properties` will be created using the settings as defined in the manual. Otherwise the rest of the settings in this document are ignored.
-      example: "/opt/jolokia/custom.properties"
-    - name: AB_JOLOKIA_HOST
-      description: Host address to bind to. Defaults to **0.0.0.0**.
-      example: "127.0.0.1"
-    - name: AB_JOLOKIA_PORT
-      description: Port to listen to. Defaults to **8778**.
-      example: "5432"
-    - name: AB_JOLOKIA_USER
-      description: User for basic authentication. Defaults to **jolokia**.
-      example: "myusername"
-    - name: AB_JOLOKIA_PASSWORD
-      description: Password for basic authentication. By default authentication is switched off.
-      example: "mypassword"
-    - name: AB_JOLOKIA_PASSWORD_RANDOM
-      description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
-      example: "true"
-    - name: AB_JOLOKIA_HTTPS
-      description: Switch on secure communication with https. By default self signed server certificates are generated if no `serverCert` configuration is given in **AB_JOLOKIA_OPTS**.
-      example: "true"
-    - name: AB_JOLOKIA_ID
-      description: Agent ID to use (`$HOSTNAME` by default, which is the container id).
-      example: "openjdk-app-1-xqlsj"
-    - name: AB_JOLOKIA_DISCOVERY_ENABLED
-      description: Enable Jolokia discovery. Defaults to **false**.
-      example: "true"
-    - name: AB_JOLOKIA_OPTS
-      description: Additional options to be appended to the agent configuration. They should be given in the format `key=value,key=value,...`.
-      example: "backlog=20"
-    - name: AB_JOLOKIA_AUTH_OPENSHIFT
-      description: Switch on client authentication for OpenShift TLS communication. The value of this parameter can be a relative distinguished name which must be contained in a presented client's certificate. Enabling this parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
-      example: "true"
     - name: SCRIPT_DEBUG
       description: If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
       example: "true"
@@ -142,7 +100,6 @@ envs:
       description: Disable the boot errors check in the probes.
 ports:
     - value: 8443
-    - value: 8778
 modules:
       repositories:
           - name: cct_module
@@ -190,8 +147,6 @@ packages:
           - python-enum34
           - PyYAML
 artifacts:
-    - url: https://maven.repository.redhat.com/ga/org/jolokia/jolokia-jvm/1.3.6.redhat-1/jolokia-jvm-1.3.6.redhat-1-agent.jar
-      md5: 75e5b5ba0b804cd9def9f20a70af649f
     - path: javax.json-1.0.4.jar
       md5: 569870f975deeeb6691fcb9bc02a9555
     - path: jboss-logmanager-ext-1.0.0.Alpha2-redhat-1.jar

--- a/image.yaml
+++ b/image.yaml
@@ -105,7 +105,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-14
+                  ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common


### PR DESCRIPTION
This PR is syncing the content of the ```sso72-cp`` branch with necessary commits from ```sso72-dev``` branch after the RH-SSO 7.2.0.GA image has been released.

Out of the four ```sso72-cp``` vs ```sso72-dev``` [differing changes](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/compare/sso72-cp...sso72-dev), we need to apply for ```sso72-cp``` branch only the following two commits:
* [Point the cct_module reference back to 'master'](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/commit/1b7d20193d3f3dea2a08b3c6031ad4c9b9420d7f) and
* [CLOUD-2314 bump jolokia to 1.5.0](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/commit/a5fcdd08860cddfc8c41657d134d31ad264c0fb7)

Note: Once this PR is merged, a compare PR containing these two changes will be created against ```sso72``` branch too.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
