### PR TITLE
[CE Sprint #16] [CLOUD-2398] Include the openssl rpm (and binary) in the RH-SSO for OpenShift image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -148,7 +148,7 @@ packages:
           - python-requests
           - python-enum34
           - PyYAML
-
+          - openssl
 run:
       user: 185
       cmd:


### PR DESCRIPTION
<br/>
So we can utilize the OpenShift's serving x509 certificate secrets service to autogenerate keystores and truststore for the RH-SSO server<br>
<br/>
Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
