### PR TITLE
Use override file to set cp's build and module branches

### DIFF
--- a/override-cp.yaml
+++ b/override-cp.yaml
@@ -1,0 +1,8 @@
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  ref: sprint-16
+osbs:
+      repository:
+            branch: jb-sso-7.2-openshift-cp-rhel-7


### PR DESCRIPTION
To be used like this: `--overrides override-cp.yaml`

The build branch is set to `-cp-rhel-7`, which contains a `container.yaml`,
causing the OSBS build tag to be :cp instead of :latest.

The module branch is set to sprint-16, so that any post-sprint-16 changes do
not affect builds here. When future sprints become stable, this branch ref can
be updated.
