### PR TITLE
[CLOUD-2453][KEYCLOAK-7098] Include nmap-ncat RPM into RH-SSO 7.3 TP CD image

### DIFF
--- a/modules/sso/config/launch/setup/73/module.yaml
+++ b/modules/sso/config/launch/setup/73/module.yaml
@@ -15,6 +15,7 @@ packages:
           - jboss-os
       install:
           - openssl
+          - nmap-ncat
 
 execute:
 - script: configure.sh

--- a/templates/sso-cd-mysql-persistent.json
+++ b/templates/sso-cd-mysql-persistent.json
@@ -440,7 +440,32 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Recreate",
+                    "customParams": {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
+                            "until nc -w 3 ${DB_SERVICE} ${DB_PORT} &> /dev/null; do [[ -n \"${PV_CLAIM_MESSAGE}\" ]] && echo \"${PV_CLAIM_MESSAGE}\" && unset PV_CLAIM_MESSAGE; echo \"${SRV_WAIT_MESSAGE}\"; sleep 10; done; openshift-deploy"
+                        ],
+                        "environment": [
+                            {
+                                "name": "DB_SERVICE",
+                                "value": "${APPLICATION_NAME}-mysql"
+                            },
+                            {
+                                "name": "DB_PORT",
+                                "value": "3306"
+                            },
+                            {
+                                "name": "PV_CLAIM_MESSAGE",
+                                "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set."
+                            },
+                            {
+                                "name": "SRV_WAIT_MESSAGE",
+                                "value": "Waiting for the \"${APPLICATION_NAME}-mysql\" service to become available.."
+                            }
+                        ]
+                    }
                 },
                 "triggers": [
                     {

--- a/templates/sso-cd-mysql.json
+++ b/templates/sso-cd-mysql.json
@@ -439,7 +439,28 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Recreate",
+                    "customParams": {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
+                            "until nc -w 3 ${DB_SERVICE} ${DB_PORT} &> /dev/null; do echo \"${SRV_WAIT_MESSAGE}\"; sleep 10; done; openshift-deploy"
+                        ],
+                        "environment": [
+                            {
+                                "name": "DB_SERVICE",
+                                "value": "${APPLICATION_NAME}-mysql"
+                            },
+                            {
+                                "name": "DB_PORT",
+                                "value": "3306"
+                            },
+                            {
+                                "name": "SRV_WAIT_MESSAGE",
+                                "value": "Waiting for the \"${APPLICATION_NAME}-mysql\" service to become available.."
+                            }
+                        ]
+                    }
                 },
                 "triggers": [
                     {

--- a/templates/sso-cd-postgresql-persistent.json
+++ b/templates/sso-cd-postgresql-persistent.json
@@ -422,7 +422,32 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Recreate",
+                    "customParams": {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
+                            "until nc -w 3 ${DB_SERVICE} ${DB_PORT} &> /dev/null; do [[ -n \"${PV_CLAIM_MESSAGE}\" ]] && echo \"${PV_CLAIM_MESSAGE}\" && unset PV_CLAIM_MESSAGE; echo \"${SRV_WAIT_MESSAGE}\"; sleep 10; done; openshift-deploy"
+                        ],
+                        "environment": [
+                            {
+                                "name": "DB_SERVICE",
+                                "value": "${APPLICATION_NAME}-postgresql"
+                            },
+                            {
+                                "name": "DB_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PV_CLAIM_MESSAGE",
+                                "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set."
+                            },
+                            {
+                                "name": "SRV_WAIT_MESSAGE",
+                                "value": "Waiting for the \"${APPLICATION_NAME}-postgresql\" service to become available.."
+                            }
+                        ]
+                    }
                 },
                 "triggers": [
                     {

--- a/templates/sso-cd-postgresql.json
+++ b/templates/sso-cd-postgresql.json
@@ -421,7 +421,28 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Recreate",
+                    "customParams": {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
+                            "until nc -w 3 ${DB_SERVICE} ${DB_PORT} &> /dev/null; do echo \"${SRV_WAIT_MESSAGE}\"; sleep 10; done; openshift-deploy"
+                        ],
+                        "environment": [
+                            {
+                                "name": "DB_SERVICE",
+                                "value": "${APPLICATION_NAME}-postgresql"
+                            },
+                            {
+                                "name": "DB_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "SRV_WAIT_MESSAGE",
+                                "value": "Waiting for the \"${APPLICATION_NAME}-postgresql\" service to become available.."
+                            }
+                        ]
+                    }
                 },
                 "triggers": [
                     {

--- a/templates/sso-cd-x509-mysql-persistent.json
+++ b/templates/sso-cd-x509-mysql-persistent.json
@@ -298,7 +298,32 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Recreate",
+                    "customParams": {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
+                            "until nc -w 3 ${DB_SERVICE} ${DB_PORT} &> /dev/null; do [[ -n \"${PV_CLAIM_MESSAGE}\" ]] && echo \"${PV_CLAIM_MESSAGE}\" && unset PV_CLAIM_MESSAGE; echo \"${SRV_WAIT_MESSAGE}\"; sleep 10; done; openshift-deploy"
+                        ],
+                        "environment": [
+                            {
+                                "name": "DB_SERVICE",
+                                "value": "${APPLICATION_NAME}-mysql"
+                            },
+                            {
+                                "name": "DB_PORT",
+                                "value": "3306"
+                            },
+                            {
+                                "name": "PV_CLAIM_MESSAGE",
+                                "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set."
+                            },
+                            {
+                                "name": "SRV_WAIT_MESSAGE",
+                                "value": "Waiting for the \"${APPLICATION_NAME}-mysql\" service to become available.."
+                            }
+                        ]
+                    }
                 },
                 "triggers": [
                     {

--- a/templates/sso-cd-x509-postgresql-persistent.json
+++ b/templates/sso-cd-x509-postgresql-persistent.json
@@ -280,7 +280,32 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Recreate",
+                    "customParams": {
+                        "command": [
+                            "/bin/sh",
+                            "-c",
+                            "until nc -w 3 ${DB_SERVICE} ${DB_PORT} &> /dev/null; do [[ -n \"${PV_CLAIM_MESSAGE}\" ]] && echo \"${PV_CLAIM_MESSAGE}\" && unset PV_CLAIM_MESSAGE; echo \"${SRV_WAIT_MESSAGE}\"; sleep 10; done; openshift-deploy"
+                        ],
+                        "environment": [
+                            {
+                                "name": "DB_SERVICE",
+                                "value": "${APPLICATION_NAME}-postgresql"
+                            },
+                            {
+                                "name": "DB_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PV_CLAIM_MESSAGE",
+                                "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set."
+                            },
+                            {
+                                "name": "SRV_WAIT_MESSAGE",
+                                "value": "Waiting for the \"${APPLICATION_NAME}-postgresql\" service to become available.."
+                            }
+                        ]
+                    }
                 },
                 "triggers": [
                     {


### PR DESCRIPTION
Yet deploy RH-SSO pod only if DB service is ready, when provisioning from DB RH-SSO templates

**Note:** This is the 7.3 TP CD all-in-one counterpart of [7.2 cct_module](https://github.com/jboss-openshift/cct_module/pull/292) and [7.2 templates](https://github.com/jboss-openshift/application-templates/pull/484) change

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
