### PR TITLE
[DO NOT MERGE][CLOUD-2453][KEYCLOAK-7098] Add wait_for_service launch script routine

### DIFF
--- a/docs/templates/sso-cd-mysql-persistent.adoc
+++ b/docs/templates/sso-cd-mysql-persistent.adoc
@@ -200,7 +200,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.32+| `${APPLICATION_NAME}`
+.34+| `${APPLICATION_NAME}`
 |`SSO_HOSTNAME` | Custom hostname for the RH-SSO server. | `${SSO_HOSTNAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
@@ -225,6 +225,8 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-mysql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-mysql-claim" or a storage class is set.
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso-cd-mysql.adoc
+++ b/docs/templates/sso-cd-mysql.adoc
@@ -199,7 +199,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.32+| `${APPLICATION_NAME}`
+.33+| `${APPLICATION_NAME}`
 |`SSO_HOSTNAME` | Custom hostname for the RH-SSO server. | `${SSO_HOSTNAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
@@ -224,6 +224,7 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-mysql`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso-cd-postgresql-persistent.adoc
+++ b/docs/templates/sso-cd-postgresql-persistent.adoc
@@ -197,7 +197,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.32+| `${APPLICATION_NAME}`
+.34+| `${APPLICATION_NAME}`
 |`SSO_HOSTNAME` | Custom hostname for the RH-SSO server. | `${SSO_HOSTNAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
@@ -222,6 +222,8 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-postgresql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-postgresql-claim" or a storage class is set.
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso-cd-postgresql.adoc
+++ b/docs/templates/sso-cd-postgresql.adoc
@@ -196,7 +196,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.32+| `${APPLICATION_NAME}`
+.33+| `${APPLICATION_NAME}`
 |`SSO_HOSTNAME` | Custom hostname for the RH-SSO server. | `${SSO_HOSTNAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
@@ -221,6 +221,7 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-postgresql`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso-cd-x509-mysql-persistent.adoc
+++ b/docs/templates/sso-cd-x509-mysql-persistent.adoc
@@ -182,7 +182,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.20+| `${APPLICATION_NAME}`
+.22+| `${APPLICATION_NAME}`
 |`SSO_HOSTNAME` | Custom hostname for the RH-SSO server. | `${SSO_HOSTNAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
@@ -198,6 +198,8 @@ for more information.
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
 |X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-mysql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-mysql-claim" or a storage class is set.
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso-cd-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso-cd-x509-postgresql-persistent.adoc
@@ -179,7 +179,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.20+| `${APPLICATION_NAME}`
+.22+| `${APPLICATION_NAME}`
 |`SSO_HOSTNAME` | Custom hostname for the RH-SSO server. | `${SSO_HOSTNAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
@@ -195,6 +195,8 @@ for more information.
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
 |X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-postgresql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-postgresql-claim" or a storage class is set.
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/image.yaml
+++ b/image.yaml
@@ -18,21 +18,9 @@ labels:
     - name: "io.openshift.s2i.scripts-url"
       value: "image:///usr/local/s2i"
 envs:
-    - name: "SSO_ADMIN_USERNAME"
-      example: "admin"
-      description: "Username of the administrator account for the 'master' realm of the SSO server. Required. If no value is specified, it is auto generated and displayed as an OpenShift Instructional message when the template is instantiated."
-    - name: "SSO_ADMIN_PASSWORD"
-      example: "hardtoguess"
-      description: "Password of the administrator account for the 'master' realm of the SSO server. Required. If no value is specified, it is auto generated and displayed as an OpenShift Instructional message when the template is instantiated."
     - name: "SSO_REALM"
       example: "demo"
       description: "SSO Realm created if this ENV is provided"
-    - name: "SSO_SERVICE_USERNAME"
-      example: "username"
-      description: "SSO Server service username with rights to create Client configurations in SSO_REALM. This user is created if this ENV is provided"
-    - name: "SSO_SERVICE_PASSWORD"
-      example: "password"
-      description: "Password for SSO_SERVICE_USERNAME"
     - name: "SSO_TRUSTSTORE"
       example: "truststore.jks"
       description: "The name of the truststore file within the secret"
@@ -45,8 +33,8 @@ envs:
     - name: "SSO_TRUSTSTORE_SECRET"
       example: "truststore-secret"
       description: "The name of the secret containing the truststore file. Used for volume secretName"
-    - name: SCRIPT_DEBUG
-      description: If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
+    - name: "SCRIPT_DEBUG"
+      description: "If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed."
       example: "true"
 ports:
     - value: 8443

--- a/modules/sso/config/launch/setup/73/added/openshift-launch.sh
+++ b/modules/sso/config/launch/setup/73/added/openshift-launch.sh
@@ -11,10 +11,39 @@ function clean_shutdown() {
   wait $!
 }
 
+# CLOUD-2453 Connect-retry loop to wait for the service to become reachable over network
+function wait_for_service() {
+  if [ -n "${SERVICE_WAIT_NAME}" ]; then
+    local -r retry_period_seconds_default="10"
+    local -r connect_retry_message="${SERVICE_WAIT_RETRY_MESSAGE:-"Waiting for the \"${SERVICE_WAIT_NAME}\" service to become available ..."}"
+    local service="${SERVICE_WAIT_NAME/-/_}"
+    local -r service_host="${service^^}_SERVICE_HOST"
+    local -r service_port="${service^^}_SERVICE_PORT"
+    if [ -n "${SERVICE_WAIT_RETRY_PERIOD_SECONDS}" ] && [[ ! "${SERVICE_WAIT_RETRY_PERIOD_SECONDS}" =~ '^[0-9]+\.?[0-9]*$' ]]; then
+      log_warning "Value of SERVICE_WAIT_RETRY_PERIOD_SECONDS variable can be only arbitrary floating point number. Ignoring \"${SERVICE_WAIT_RETRY_PERIOD_SECONDS}\" setting, defaulting to ${retry_period_seconds_default} seconds."
+      unset SERVICE_WAIT_RETRY_PERIOD_SECONDS
+    fi
+    if [ -z "${!service_host}" -o -z "${!service_port}" ]; then
+      log_warning "Unable to determine target host or port of the \"${SERVICE_WAIT_NAME}\" service. The RH-SSO pod will start without waiting for the \"${SERVICE_WAIT_NAME}\" service to become reachable over network. Please make sure you specified correct service name in SERVICE_WAIT_NAME."
+    else
+      until ( echo > /dev/tcp/"${!service_host}"/"${!service_port}" ) &> /dev/null; do
+        if [ -n "${SERVICE_WAIT_INTRO_MESSAGE}" ]; then
+          log_warning "${SERVICE_WAIT_INTRO_MESSAGE}"
+          unset SERVICE_WAIT_INTRO_MESSAGE
+        fi
+          log_info "${connect_retry_message}"
+          sleep "${SERVICE_WAIT_RETRY_PERIOD_SECONDS:-${retry_period_seconds_default}}s"
+      done
+    fi
+  fi
+}
+
 function runServer() {
   local instanceDir=$1
   local count=$2
   export NODE_NAME="${NODE_NAME:-node}-${count}"
+
+  wait_for_service
 
   source $JBOSS_HOME/bin/launch/configure.sh
 
@@ -51,6 +80,8 @@ if [ "${SPLIT_DATA^^}" = "TRUE" ]; then
 
   partitionPV "${DATA_DIR}" "${SPLIT_LOCK_TIMEOUT:-30}"
 else
+  wait_for_service
+
   source $JBOSS_HOME/bin/launch/configure.sh
 
   log_info "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"

--- a/modules/sso/config/launch/setup/73/module.yaml
+++ b/modules/sso/config/launch/setup/73/module.yaml
@@ -23,3 +23,26 @@ run:
       user: 185
       cmd:
           - "/opt/eap/bin/openshift-launch.sh"
+
+envs:
+    - name: "SERVICE_WAIT_NAME"
+      example: "sso-mysql"
+      description: "Name of the OpenShift service, the RH-SSO pod should wait for to become reachable over network, prior starting the RH-SSO server. Not set by default."
+    - name: "SERVICE_WAIT_RETRY_MESSAGE"
+      example: "Waiting for the \"${SERVICE_WAIT_NAME}\" service to become reachable over network ..."
+      description: "Message to be displayed in connect-retry loop, in which the RH-SSO pod is waiting for the SERVICE_WAIT_NAME to become reachable over network. Defaults to 'Waiting for the \"${SERVICE_WAIT_NAME}\" service to become available ....' if the SERVICE_WAIT_NAME variable is set."
+    - name: "SERVICE_WAIT_INTRO_MESSAGE"
+      example: "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set."
+      description: "Message to be displayed prior starting the connect-retry loop, in which the RH-SSO pod is waiting for the SERVICE_WAIT_NAME to become reachable over network. Typically describes additional requirements in order the connect-retry loop of the RH-SSO pod successfully to finish. Not set by default."
+    - name: "SSO_ADMIN_USERNAME"
+      example: "admin"
+      description: "Username of the administrator account for the 'master' realm of the RH-SSO server. Required. If no value is specified, it is auto generated and displayed as an OpenShift Instructional message when the template is instantiated."
+    - name: "SSO_ADMIN_PASSWORD"
+      example: "hardtoguess"
+      description: "Password of the administrator account for the 'master' realm of the RH-SSO server. Required. If no value is specified, it is auto generated and displayed as an OpenShift Instructional message when the template is instantiated."
+    - name: "SSO_SERVICE_USERNAME"
+      example: "username"
+      description: "RH-SSO Server service username with rights to create Client configurations in SSO_REALM. This user is created if this ENV is provided"
+    - name: "SSO_SERVICE_PASSWORD"
+      example: "password"
+      description: "Password for SSO_SERVICE_USERNAME"

--- a/templates/sso-cd-mysql-persistent.json
+++ b/templates/sso-cd-mysql-persistent.json
@@ -641,6 +641,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso-cd-mysql.json
+++ b/templates/sso-cd-mysql.json
@@ -641,6 +641,10 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso-cd-postgresql-persistent.json
+++ b/templates/sso-cd-postgresql-persistent.json
@@ -623,6 +623,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-postgresql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso-cd-postgresql.json
+++ b/templates/sso-cd-postgresql.json
@@ -623,6 +623,10 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-postgresql"
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso-cd-x509-mysql-persistent.json
+++ b/templates/sso-cd-x509-mysql-persistent.json
@@ -458,6 +458,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso-cd-x509-postgresql-persistent.json
+++ b/templates/sso-cd-x509-postgresql-persistent.json
@@ -440,6 +440,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-postgresql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },


### PR DESCRIPTION

    [CLOUD-2453][KEYCLOAK-7098] Add wait_for_service launch script routine.
    Deploy RH-SSO pod only if DB service is ready, when provisioning from
    DB RH-SSO templates
    
    Describe and add example values for the newly introduced SERVICE_WAIT_NAME,
    SERVICE_WAIT_RETRY_MESSAGE, and SERVICE_WAIT_INTRO_MESSAGE
    environment variables
    
    Also move the description of SSO_ADMIN_USERNAME, SSO_ADMIN_PASSWORD,
    SSO_SERVICE_USERNAME, and SSO_SERVICE_PASSWORD variables from image.yaml
    to sso/config/launch/setup/73/module.yaml. These variables aren't used /
    referenced outside of this module

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
