### PR TITLE
[KEYCLOAK-8426] Bump to 'sprint-24' cct_module version

### DIFF
--- a/override-cp.yaml
+++ b/override-cp.yaml
@@ -4,7 +4,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-19
+                  ref: sprint-24
 osbs:
       repository:
             name: containers/redhat-sso-7


### PR DESCRIPTION
Use [`CE Sprint 24 cct_module version`](https://github.com/jboss-openshift/cct_module/tree/sprint-24) for RH-SSO 7.2.5.GA

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
