### PR TITLE
[KEYCLOAK-7565] Replace former xpaas label and version with new RH-SSO ones

### DIFF
--- a/templates/sso70-image-stream.json
+++ b/templates/sso70-image-stream.json
@@ -18,11 +18,11 @@
                     "description": "Red Hat SSO 7.0",
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.0",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.16"
+                    "version": "1.2.0"
                 }
             },
             "labels": {
-                "xpaas": "1.4.16"
+                "rh-sso": "1.2.0"
             },
             "spec": {
                 "tags": [

--- a/templates/sso71-image-stream.json
+++ b/templates/sso71-image-stream.json
@@ -18,11 +18,11 @@
                     "description": "Red Hat SSO 7.1",
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.1",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.16"
+                    "version": "1.2.0"
                 }
             },
             "labels": {
-                "xpaas": "1.4.16"
+                "rh-sso": "1.2.0"
             },
             "spec": {
                 "tags": [

--- a/templates/sso72-https.json
+++ b/templates/sso72-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-https",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso72-image-stream.json
+++ b/templates/sso72-image-stream.json
@@ -18,11 +18,11 @@
                     "description": "Red Hat SSO 7.2",
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.2",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.16"
+                    "version": "1.2.0"
                 }
             },
             "labels": {
-                "xpaas": "1.4.16"
+                "rh-sso": "1.2.0"
             },
             "spec": {
                 "tags": [

--- a/templates/sso72-mysql-persistent.json
+++ b/templates/sso72-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + MySQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-mysql-persistent",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso72-mysql.json
+++ b/templates/sso72-mysql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + MySQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-mysql",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso72-postgresql-persistent.json
+++ b/templates/sso72-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + PostgreSQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-postgresql-persistent",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso72-postgresql.json
+++ b/templates/sso72-postgresql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + PostgreSQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-postgresql",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso72-x509-https.json
+++ b/templates/sso72-x509-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-x509-https",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso72-x509-mysql-persistent.json
+++ b/templates/sso72-x509-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + MySQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-x509-mysql-persistent",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso72-x509-postgresql-persistent.json
+++ b/templates/sso72-x509-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "1.4.16",
+            "version": "1.2.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2 + PostgreSQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso72-x509-postgresql-persistent",
-        "xpaas": "1.4.16"
+        "rh-sso": "1.2.0"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [


### PR DESCRIPTION
Replace '"xpaas": "1.4.16"' label with '"rh-sso": "12.0"' one, and '"version": "1.4.16"' with '"version": "1.2.0"'

Note: This should have been done within CLOUD-2709 / KEYCLOAK-7565 move, but forgot to do it earlier. Thus doing via another PR.

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
