### PR TITLE
[DO NOT MERGE][CLOUD-2453][KEYCLOAK-7098] Deploy RH-SSO pod only if DB service is ready

### DIFF
--- a/docs/templates/sso72-mysql-persistent.adoc
+++ b/docs/templates/sso72-mysql-persistent.adoc
@@ -199,7 +199,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.31+| `${APPLICATION_NAME}`
+.33+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -223,6 +223,8 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-mysql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-mysql-claim" or a storage class is set.
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso72-mysql.adoc
+++ b/docs/templates/sso72-mysql.adoc
@@ -198,7 +198,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.31+| `${APPLICATION_NAME}`
+.32+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -222,6 +222,7 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-mysql`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso72-postgresql-persistent.adoc
+++ b/docs/templates/sso72-postgresql-persistent.adoc
@@ -196,7 +196,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.31+| `${APPLICATION_NAME}`
+.33+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -220,6 +220,8 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-postgresql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-postgresql-claim" or a storage class is set.
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso72-postgresql.adoc
+++ b/docs/templates/sso72-postgresql.adoc
@@ -195,7 +195,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.31+| `${APPLICATION_NAME}`
+.32+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -219,6 +219,7 @@ for more information.
 |`JGROUPS_ENCRYPT_NAME` | The name associated with the server certificate (e.g. secret-key) | `${JGROUPS_ENCRYPT_NAME}`
 |`JGROUPS_ENCRYPT_PASSWORD` | The password for the keystore and certificate (e.g. password) | `${JGROUPS_ENCRYPT_PASSWORD}`
 |`JGROUPS_CLUSTER_PASSWORD` | JGroups cluster password | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-postgresql`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
 |`SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}`

--- a/docs/templates/sso72-x509-mysql-persistent.adoc
+++ b/docs/templates/sso72-x509-mysql-persistent.adoc
@@ -181,7 +181,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.20+| `${APPLICATION_NAME}`
+.22+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-mysql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -196,6 +196,8 @@ for more information.
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
 |X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-mysql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-mysql-claim" or a storage class is set.
 |`JGROUPS_ENCRYPT_PROTOCOL` | -- | `ASYM_ENCRYPT`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`

--- a/docs/templates/sso72-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso72-x509-postgresql-persistent.adoc
@@ -178,7 +178,7 @@ for more information.
 |=======================================================================
 |Deployment |Variable name |Description |Example value
 
-.20+| `${APPLICATION_NAME}`
+.22+| `${APPLICATION_NAME}`
 |`DB_SERVICE_PREFIX_MAPPING` | -- | `${APPLICATION_NAME}-postgresql=DB`
 |`DB_JNDI` | Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql | `${DB_JNDI}`
 |`DB_USERNAME` | Database user name | `${DB_USERNAME}`
@@ -193,6 +193,8 @@ for more information.
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
 |X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
+|`SERVICE_WAIT_NAME` | -- | `${APPLICATION_NAME}-postgresql`
+|`SERVICE_WAIT_INTRO_MESSAGE` | -- | Ensure a persistent volume is available for the "${APPLICATION_NAME}-postgresql-claim" or a storage class is set.
 |`JGROUPS_ENCRYPT_PROTOCOL` | -- | `ASYM_ENCRYPT`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`

--- a/image.yaml
+++ b/image.yaml
@@ -18,21 +18,9 @@ labels:
     - name: "io.openshift.s2i.scripts-url"
       value: "image:///usr/local/s2i"
 envs:
-    - name: "SSO_ADMIN_USERNAME"
-      example: "admin"
-      description: "Username of the administrator account for the 'master' realm of the SSO server. Required. If no value is specified, it is auto generated and displayed as an OpenShift Instructional message when the template is instantiated."
-    - name: "SSO_ADMIN_PASSWORD"
-      example: "hardtoguess"
-      description: "Password of the administrator account for the 'master' realm of the SSO server. Required. If no value is specified, it is auto generated and displayed as an OpenShift Instructional message when the template is instantiated."
     - name: "SSO_REALM"
       example: "demo"
       description: "SSO Realm created if this ENV is provided"
-    - name: "SSO_SERVICE_USERNAME"
-      example: "username"
-      description: "SSO Server service username with rights to create Client configurations in SSO_REALM. This user is created if this ENV is provided"
-    - name: "SSO_SERVICE_PASSWORD"
-      example: "password"
-      description: "Password for SSO_SERVICE_USERNAME"
     - name: "SSO_TRUSTSTORE"
       example: "truststore.jks"
       description: "The name of the truststore file within the secret"
@@ -45,8 +33,8 @@ envs:
     - name: "SSO_TRUSTSTORE_SECRET"
       example: "truststore-secret"
       description: "The name of the secret containing the truststore file. Used for volume secretName"
-    - name: SCRIPT_DEBUG
-      description: If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed.
+    - name: "SCRIPT_DEBUG"
+      description: "If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed."
       example: "true"
 ports:
     - value: 8443

--- a/templates/sso72-mysql-persistent.json
+++ b/templates/sso72-mysql-persistent.json
@@ -630,6 +630,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso72-mysql.json
+++ b/templates/sso72-mysql.json
@@ -630,6 +630,10 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso72-postgresql-persistent.json
+++ b/templates/sso72-postgresql-persistent.json
@@ -612,6 +612,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-postgresql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso72-postgresql.json
+++ b/templates/sso72-postgresql.json
@@ -612,6 +612,10 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-postgresql"
+                                    },
+                                    {
                                         "name": "SSO_ADMIN_USERNAME",
                                         "value": "${SSO_ADMIN_USERNAME}"
                                     },

--- a/templates/sso72-x509-mysql-persistent.json
+++ b/templates/sso72-x509-mysql-persistent.json
@@ -441,6 +441,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-mysql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-mysql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_PROTOCOL",
                                         "value": "ASYM_ENCRYPT"
                                     },

--- a/templates/sso72-x509-postgresql-persistent.json
+++ b/templates/sso72-x509-postgresql-persistent.json
@@ -423,6 +423,14 @@
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
                                     },
                                     {
+                                        "name": "SERVICE_WAIT_NAME",
+                                        "value": "${APPLICATION_NAME}-postgresql"
+                                    },
+                                    {
+                                        "name": "SERVICE_WAIT_INTRO_MESSAGE",
+                                        "value": "Ensure a persistent volume is available for the \"${APPLICATION_NAME}-postgresql-claim\" or a storage class is set."
+                                    },
+                                    {
                                         "name": "JGROUPS_ENCRYPT_PROTOCOL",
                                         "value": "ASYM_ENCRYPT"
                                     },


### PR DESCRIPTION
This PR is performing the following:

    * [CLOUD-2453][KEYCLOAK-7098] Move description of SSO_ADMIN_USERNAME,
      SSO_ADMIN_PASSWORD, SSO_SERVICE_USERNAME, and SSO_SERVICE_PASSWORD
      variables from image.yaml to os-sso/module.yaml
    
      These variables aren't used / referenced outside of some of os-sso,
      os-sso71, and os-sso72 modules, and for the future we want one
      common 'os-sso' module, sharing all the parts common to all
      RH-SSO images. This move is part of such unification

    * [CLOUD-2453][KEYCLOAK-7098] Deploy RH-SSO pod only if DB
      service is ready, when provisioning from DB RH-SSO templates

Note: It is a replacement one for https://github.com/jboss-openshift/application-templates/pull/485 one (since the RH-SSO 7.2 templates were moved, the changes need to be done against new location)

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
