### PR TITLE
[KEYCLOAK-9120] Switch the cct_module branch to 'sprint-27'

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -55,7 +55,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+                  ref: sprint-27
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git


### PR DESCRIPTION
Since:
1) It is more stable than 'master' (tested), and
2) Still contains the necessary EAP cct_modules, that were moved
   as part of 'CLOUD-2954' effort to jboss-eap-modules repository.

This will make the build of 'redhat-sso-7/sso73-openshift' image to
pass again till jboss-eap-modules is tagged with CLOUD-2954 changes

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
