### PR TITLE
[KEYCLOAK-8428] move image stream label to metadata

### DIFF
--- a/templates/sso70-image-stream.json
+++ b/templates/sso70-image-stream.json
@@ -19,10 +19,10 @@
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.0",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "rh-sso-7.2-v1.3.0"
+                },
+                "labels": {
+                    "rh-sso": "7.2-v1.3.0"
                 }
-            },
-            "labels": {
-                "rh-sso": "7.2-v1.3.0"
             },
             "spec": {
                 "tags": [

--- a/templates/sso71-image-stream.json
+++ b/templates/sso71-image-stream.json
@@ -19,10 +19,10 @@
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.1",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "rh-sso-7.2-v1.3.0"
+                },
+                "labels": {
+                    "rh-sso": "7.2-v1.3.0"
                 }
-            },
-            "labels": {
-                "rh-sso": "7.2-v1.3.0"
             },
             "spec": {
                 "tags": [

--- a/templates/sso72-image-stream.json
+++ b/templates/sso72-image-stream.json
@@ -19,10 +19,10 @@
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.2",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "rh-sso-7.2-v1.3.0"
+                },
+                "labels": {
+                    "rh-sso": "7.2-v1.3.0"
                 }
-            },
-            "labels": {
-                "rh-sso": "7.2-v1.3.0"
             },
             "spec": {
                 "tags": [


### PR DESCRIPTION
This PR makes the image streams usable, instead of them being invalid OpenShift objects.