### PR TITLE
[RHSSO-1737] Sync with EAP 7.2.1 modules change. Update templates

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -16,14 +16,14 @@ toc::[levels=1]
 
 == templates
 
-* link:./templates/sso73-https.adoc[sso-cd-https]
-* link:./templates/sso73-mysql-persistent.adoc[sso-cd-mysql-persistent]
-* link:./templates/sso73-mysql.adoc[sso-cd-mysql]
-* link:./templates/sso73-postgresql-persistent.adoc[sso-cd-postgresql-persistent]
-* link:./templates/sso73-postgresql.adoc[sso-cd-postgresql]
-* link:./templates/sso73-x509-https.adoc[sso-cd-x509-https]
-* link:./templates/sso73-x509-mysql-persistent.adoc[sso-cd-x509-mysql-persistent]
-* link:./templates/sso73-x509-postgresql-persistent.adoc[sso-cd-x509-postgresql-persistent]
+* link:./templates/sso73-https.adoc[sso73-https]
+* link:./templates/sso73-mysql-persistent.adoc[sso73-mysql-persistent]
+* link:./templates/sso73-mysql.adoc[sso73-mysql]
+* link:./templates/sso73-postgresql-persistent.adoc[sso73-postgresql-persistent]
+* link:./templates/sso73-postgresql.adoc[sso73-postgresql]
+* link:./templates/sso73-x509-https.adoc[sso73-x509-https]
+* link:./templates/sso73-x509-mysql-persistent.adoc[sso73-x509-mysql-persistent]
+* link:./templates/sso73-x509-postgresql-persistent.adoc[sso73-x509-postgresql-persistent]
 
 ////
   the source for the release notes part of this page is in the file

--- a/docs/templates/sso73-https.adoc
+++ b/docs/templates/sso73-https.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-https
+= sso73-https
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/docs/templates/sso73-mysql-persistent.adoc
+++ b/docs/templates/sso73-mysql-persistent.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-mysql-persistent
+= sso73-mysql-persistent
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/docs/templates/sso73-mysql.adoc
+++ b/docs/templates/sso73-mysql.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-mysql
+= sso73-mysql
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/docs/templates/sso73-postgresql-persistent.adoc
+++ b/docs/templates/sso73-postgresql-persistent.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-postgresql-persistent
+= sso73-postgresql-persistent
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/docs/templates/sso73-postgresql.adoc
+++ b/docs/templates/sso73-postgresql.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-postgresql
+= sso73-postgresql
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/docs/templates/sso73-x509-https.adoc
+++ b/docs/templates/sso73-x509-https.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-x509-https
+= sso73-x509-https
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/docs/templates/sso73-x509-mysql-persistent.adoc
+++ b/docs/templates/sso73-x509-mysql-persistent.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-x509-mysql-persistent
+= sso73-x509-mysql-persistent
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/docs/templates/sso73-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso73-x509-postgresql-persistent.adoc
@@ -4,7 +4,7 @@
     generator or the input template (./*.in)
 ////
 
-= sso-cd-x509-postgresql-persistent
+= sso73-x509-postgresql-persistent
 :toc:
 :toc-placement!:
 :toclevels: 5

--- a/image.yaml
+++ b/image.yaml
@@ -97,6 +97,10 @@ modules:
           - name: openshift-passwd
           - name: keycloak-layer
           - name: os-logging
+packages:
+      repositories:
+          - jboss-os
+          - jboss-rhscl
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -55,11 +55,11 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-27
+                  ref: sprint-28
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP72-CR5
+                  ref: sprint-31
           - name: sso73_modules
             path: modules
       install:

--- a/modules/sso/config/launch/setup/73/module.yaml
+++ b/modules/sso/config/launch/setup/73/module.yaml
@@ -11,8 +11,6 @@ modules:
   - name: os-eap-migration
 
 packages:
-      repositories:
-          - jboss-os
       install:
           - openssl
 

--- a/templates/sso73-https.json
+++ b/templates/sso73-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-https",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-image-stream.json
+++ b/templates/sso73-image-stream.json
@@ -18,11 +18,11 @@
                     "description": "Red Hat Single Sign-On 7.3",
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.3",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.3.0.GA"
+                    "version": "7.3.1.GA"
                 }
             },
             "labels": {
-                "rhsso": "7.3.0.GA"
+                "rhsso": "7.3.1.GA"
             },
             "spec": {
                 "tags": [

--- a/templates/sso73-mysql-persistent.json
+++ b/templates/sso73-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-mysql-persistent",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-mysql.json
+++ b/templates/sso73-mysql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-mysql",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-postgresql-persistent.json
+++ b/templates/sso73-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-postgresql-persistent",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-postgresql.json
+++ b/templates/sso73-postgresql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-postgresql",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-x509-https.json
+++ b/templates/sso73-x509-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-x509-https",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso73-x509-mysql-persistent.json
+++ b/templates/sso73-x509-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-x509-mysql-persistent",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso73-x509-postgresql-persistent.json
+++ b/templates/sso73-x509-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.3.0.GA",
+            "version": "7.3.1.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-x509-postgresql-persistent",
-        "rhsso": "7.3.0.GA"
+        "rhsso": "7.3.1.GA"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [


### PR DESCRIPTION
    [RHSSO-1737] Sync with EAP 7.2.1 modules change. Update templates
    version to '7.3.1.GA' & regenerate the docs
    
    See relevant EAP-7.2.1 changes:
      https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/215/files
      https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/215/files#r269169610
    
    for module version bump details
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
