### PR TITLE
[KEYCLOAK-10249] Inherit the original 'os-eap-db-drivers' module implementation from EAP_722 release of jboss-eap-modules. Also drop support for the MongoDB database driver

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -84,7 +84,6 @@ modules:
           - name: jboss.eap.config.elytron
           - name: os-eap-probes
           - name: jboss-maven
-          - name: os-eap-db-drivers
           - name: os-java-hawkular
           - name: os-eap70-hawkular
           - name: os-eap-hawkular
@@ -92,6 +91,7 @@ modules:
           - name: os-eap-extensions
           # RH-SSO 7.3 product specific modules from modules/ path in this repository
           - name: sso.config.launch.setup.73
+          - name: sso.db.drivers
           # Other common modules from the main CE cct_module repository
           - name: openshift-layer
           - name: openshift-passwd

--- a/modules/sso/db/drivers/added/modules/system/layers/openshift/com/mysql/main/module.xml
+++ b/modules/sso/db/drivers/added/modules/system/layers/openshift/com/mysql/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="com.mysql">
+  <resources>
+    <resource-root path="mysql-connector-java.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/modules/sso/db/drivers/added/modules/system/layers/openshift/org/postgresql/main/module.xml
+++ b/modules/sso/db/drivers/added/modules/system/layers/openshift/org/postgresql/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="org.postgresql">
+  <resources>
+    <resource-root path="postgresql-jdbc.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/modules/sso/db/drivers/configure.sh
+++ b/modules/sso/db/drivers/configure.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Link DB drivers, provided by RPM packages, into the "openshift" layer
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+
+function link {
+  mkdir -p $(dirname $2)
+  ln -s $1 $2
+}
+
+link /usr/share/java/mysql-connector-java.jar $JBOSS_HOME/modules/system/layers/openshift/com/mysql/main/mysql-connector-java.jar
+link /usr/share/java/postgresql-jdbc.jar $JBOSS_HOME/modules/system/layers/openshift/org/postgresql/main/postgresql-jdbc.jar
+
+# module definitions for MySQL and PostgreSQL
+# Remove any existing destination files first (which might be symlinks)
+cp -rp --remove-destination "$ADDED_DIR/modules" "$JBOSS_HOME/"

--- a/modules/sso/db/drivers/module.yaml
+++ b/modules/sso/db/drivers/module.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+name: sso.db.drivers
+version: '1.0'
+description: Legacy sso.db.drivers script package, derived from [EAP_722 release of os-eap-db-drivers package for JBoss EAP for OpenShift image](https://github.com/jboss-container-images/jboss-eap-modules/tree/c910472e03d6ce281654f171d56c227d493cb900/os-eap-db-drivers). Compared to the original version, the MongoDB driver was intentionally excluded.
+execute:
+- script: configure.sh
+  user: '185'
+packages:
+      install:
+          - postgresql-jdbc
+          - mysql-connector-java


### PR DESCRIPTION
Inherit the original [`os-eap-db-drivers` module implementation from `EAP_722` release of `jboss-eap-modules` repository](https://github.com/jboss-container-images/jboss-eap-modules/tree/c910472e03d6ce281654f171d56c227d493cb900/os-eap-db-drivers) into the new `sso.db.drivers` RH-SSO module.

Also drop support for the MongoDB database driver

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
