### PR TITLE
[KEYCLOAK-10694] [KEYCLOAK-10103] RHEL-8 UBI minimal / EAP CD 17 modules / CEKit 3.x support [KEYCLOAK-10124] Define RHEL-8 content set for the Red Hat Single Sign-On 7 OpenShift container image [KEYCLOAK-10556] Drop the MongoDB database driver. Replace MySQL database driver with the MariaDB [KEYCLOAK-10858] Address RH-SSO pod launch failures with MySQL & PostgreSQL DBs, leading to WFLYJCA0069 error

### DIFF
--- a/backward-compatibility/README.adoc
+++ b/backward-compatibility/README.adoc
@@ -1,0 +1,12 @@
+# Various Red Hat Single Sign-On 7 OpenShift container image link:https://docs.cekit.io/en/latest/descriptor/image.html[image descriptors] for link:https://cekit.io/[CEKit] to preserve backward compatibility
+
+This directory contains definition of various image descriptor files the Red Hat Single Sign-On 7 OpenShift container image, needed to ensure backward compatibility (reproducible image (reb)uilds over time). Such descriptor files need to be archived, in case of a major link:https://cekit.io/[CEKit] tool upgrade, leading to backward-incompatible changes, for example the link:https://cekit.io/blog/2019/04/module-merging-changes/[module merging change] introduced in link:https://cekit.io/blog/2019/04/cekit-3.0.0-released/[CEKit v3.0.0].
+
+* To build using CEKit 2.x use command:
++
+[source,bash,subs="attributes+,macros+"]
+----
+cekit build \
+--descriptor backward-compatibility/cekit-2.x-image-descriptor.yaml \
+--build-engine=docker
+----

--- a/backward-compatibility/cekit-2.x-image-descriptor.yaml
+++ b/backward-compatibility/cekit-2.x-image-descriptor.yaml
@@ -1,5 +1,22 @@
 schema_version: 1
 
+# Backward-compatible image descriptor file for the Red Hat Single Sign-On 7 OpenShift container image
+# to build the image:
+#
+# * Using CEKit 2.x,
+# * Using yum as the package manager (this assumes the parent Red Hat Single Sign-On 7 container image
+#   was based on Red Hat Enterprise Linux 7 image),
+# * Use JBoss EAP modules of version 'CD16' (or earlier) in the image.
+#
+# Due to changes introduced in CEKit 3.x (for example the "module merging change":
+#
+#   https://cekit.io/blog/2019/04/module-merging-changes/
+#
+# ), it is NOT POSSIBLE to build this specific 'image.yaml' file using CEKit 3.x!!!
+#
+# Use the 'image.yaml' from the main directory of the directory tree of this repository if building
+# the Red Hat Single Sign-On 7 OpenShift container image using CEKit 3.x is desired!
+
 name: "redhat-sso-cd-tech-preview/sso-cd-openshift"
 description: "Red Hat Single Sign-On Continuous Delivery OpenShift container image"
 version: "6"
@@ -45,7 +62,7 @@ envs:
     - name: "SSO_TRUSTSTORE_SECRET"
       example: "truststore-secret"
       description: "The name of the secret containing the truststore file. Used for volume secretName"
-    - name: "SCRIPT_DEBUG"
+    - name: SCRIPT_DEBUG
       description: "If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed."
       example: "true"
 ports:
@@ -55,44 +72,41 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+                  ref: sprint-31
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: master
+                  ref: CD16-CR1
           - name: sso73_modules
-            path: modules
+            path: ../modules
       install:
           # Order of the modules installation below matters!!! DO NOT CHANGE it unless
           # you first verified the image with changed order still works correctly
           # Common modules from the main CE cct_module repository
           - name: dynamic-resources
-          - name: jboss.container.eap.s2i.bash
+          - name: s2i-common
+          - name: java-alternatives
           - name: os-eap7-openshift
+          - name: os-eap-s2i
           - name: os-java-jolokia
           - name: jboss.eap.cd.jolokia
           - name: os-eap7-openshift
           - name: jboss.eap.cd.openshift.modules
           - name: os-eap7-ping
-          - name: jboss.container.java.jvm.bash
+          - name: os-java-run
           - name: os-eap-launch
           - name: os-eap7-launch
-          - name: os-eap-datasource
-            version: '1.0'
           - name: jboss.eap.cd.logging
           - name: jboss.eap.config.jgroups
           - name: jboss.eap.config.elytron
           - name: os-eap-probes
-            version: '2.0'
-          - name: jboss.container.maven.35.bash
-            version: '3.5'
-# Will be dealt within separate commit for separate KEYCLOAK-10556 JIRA
-#         - name: os-eap-db-drivers
+          - name: jboss-maven
+          - name: os-eap-db-drivers
+          - name: os-java-hawkular
+          - name: os-eap70-hawkular
           - name: os-eap-hawkular
           - name: os-eap-deployment-scanner
           - name: os-eap-extensions
-          - name: os-eap-python
-            version: '3.6'
           # RH-SSO 7.3 TP CD product specific modules from modules/ path in this repository
           - name: sso.config.launch.setup.73
           # Other common modules from the main CE cct_module repository
@@ -101,11 +115,9 @@ modules:
           - name: keycloak-layer
           - name: os-logging
 packages:
-      manager: microdnf
-      content_sets:
-            x86_64:
-                - rhel-8-for-x86_64-baseos-rpms
-                - rhel-8-for-x86_64-appstream-rpms
+      repositories:
+          - jboss-os
+          - jboss-rhscl
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -89,8 +89,6 @@ modules:
           - name: os-eap-hawkular
           - name: os-eap-deployment-scanner
           - name: os-eap-extensions
-          - name: os-eap-python
-            version: '3.6'
           # RH-SSO 7.3 TP CD product specific modules from modules/ path in this repository
           - name: sso.config.launch.setup.73
           - name: sso.db.drivers
@@ -104,6 +102,11 @@ modules:
           - name: os-logging
 packages:
       manager: microdnf
+      install:
+      # RHEL-8 UBI Minimal image configures python3 alternatives right by install,
+      # thus another 'alternatives --set python /usr/bin/python3' call fails
+      # Instead of using 'os-eap-python/3.6' module just install 'python36' RPM directly
+          - python36
       content_sets:
             x86_64:
                 - rhel-8-for-x86_64-baseos-rpms

--- a/image.yaml
+++ b/image.yaml
@@ -1,12 +1,12 @@
 schema_version: 1
 
-name: "redhat-sso-cd-tech-preview/sso-cd-openshift"
-description: "Red Hat Single Sign-On Continuous Delivery OpenShift container image"
+name: "redhat-sso-cd-tech-preview/sso-cd-openshift-rhel8"
+description: "Red Hat Single Sign-On Continuous Delivery OpenShift container image, based on the Red Hat Universal Base Image 8 Minimal container image"
 version: "6"
-from: "redhat-sso-cd-tech-preview/sso-cd:latest"
+from: "redhat-sso-cd-tech-preview/sso-cd-rhel8:latest"
 labels:
     - name: "com.redhat.component"
-      value: "redhat-sso-7-sso-cd-openshift-container"
+      value: "redhat-sso-cd-rhel8-openshift-container"
     - name: "io.k8s.description"
       value: "Platform for running Red Hat SSO"
     - name: "io.k8s.display-name"
@@ -115,4 +115,4 @@ run:
 osbs:
       repository:
             name: containers/redhat-sso-7
-            branch: jb-sso-cd-openshift-rhel-7
+            branch: jb-sso-cd-openshift-rhel8

--- a/image.yaml
+++ b/image.yaml
@@ -86,8 +86,6 @@ modules:
             version: '2.0'
           - name: jboss.container.maven.35.bash
             version: '3.5'
-# Will be dealt within separate commit for separate KEYCLOAK-10556 JIRA
-#         - name: os-eap-db-drivers
           - name: os-eap-hawkular
           - name: os-eap-deployment-scanner
           - name: os-eap-extensions
@@ -95,6 +93,7 @@ modules:
             version: '3.6'
           # RH-SSO 7.3 TP CD product specific modules from modules/ path in this repository
           - name: sso.config.launch.setup.73
+          - name: sso.db.drivers
           # Other common modules from the main CE cct_module repository
           - name: openshift-layer
           - name: openshift-passwd

--- a/image.yaml
+++ b/image.yaml
@@ -94,6 +94,9 @@ modules:
           # RH-SSO 7.3 TP CD product specific modules from modules/ path in this repository
           - name: sso.config.launch.setup.73
           - name: sso.db.drivers
+            version: '1.0'
+          - name: sso.datasource.overrides
+            version: '1.0'
           # Other common modules from the main CE cct_module repository
           - name: openshift-layer
           - name: openshift-passwd

--- a/modules/sso/config/launch/setup/73/added/launch/datasource.sh
+++ b/modules/sso/config/launch/setup/73/added/launch/datasource.sh
@@ -1,4 +1,8 @@
 source $JBOSS_HOME/bin/launch/datasource-common.sh
+# KEYCLOAK-10694 - Override the definitions of certain TX and XA datasource routines
+# from JBoss EAP 'os-eap-datasource' and 'os-eap7-launch' modules to replace request(s)
+# for MySQL driver with a request for the MariaDB driver in RHEL-8 UBI minimal
+source $JBOSS_HOME/bin/launch/datasource-common-overrides.sh
 
 function prepareEnv() {
   clearDatasourcesEnv
@@ -9,6 +13,42 @@ function configure() {
   NON_XA_DATASOURCE="true"
   DB_JNDI="java:jboss/datasources/KeycloakDS"
   DB_POOL="KeycloakDS"
+
+  # KEYCLOAK-10858 - if DB_SERVICE_PREFIX_MAPPING variable was provided to the pod,
+  # derive XA connection properties & DB driver information from it to avoid WFLYJCA0069 error
+  if [ -n "${DB_SERVICE_PREFIX_MAPPING}" ]; then
+    # DB_SERVICE_PREFIX_MAPPING can contain multiple DB backend definitions, separated by ",". Process them all
+    IFS=',' read -a db_backends <<< "$DB_SERVICE_PREFIX_MAPPING"
+
+    for db_backend in ${db_backends[@]}; do
+      local service_name=${db_backend%=*}
+      local service=${service_name^^}
+      service=${service//-/_}
+      local db=${service##*_}
+      local prefix=${db_backend#*=}
+
+      declare -A DB_CONNECTION_PROPERTIES=( ['ServerName']="${service}_SERVICE_HOST" ['PortNumber']="${service}_SERVICE_PORT" ['DatabaseName']="${prefix}_DATABASE" )
+      # Derive DB server name & port from automatic OpenShift variables, created for each service
+      # Derive DB server database name from the "${prefix}_DATABASE" environment variable
+      for key in "${!DB_CONNECTION_PROPERTIES[@]}"; do
+        value="${DB_CONNECTION_PROPERTIES[$key]}"
+        # Use indirect variable reference to obtain the real value of a particular environment variable (e.g. 'SSO_MYSQL_SERVICE_HOST') passed to the RH-SSO pod
+        DB_CONNECTION_PROPERTIES["$key"]="${!value}"
+      done
+
+      # Set XA connection properties (DB server name, port number & database name) to avoid WFLYJCA0069 error
+      # Thus assign those indirect reference variable values (current values of DB_CONNECTION_PROPERTIES hash)
+      # to newly created environment variable with a proper ${prefix}_XA_CONNECTION_PROPERTY_* name
+      printf -v "${prefix}_XA_CONNECTION_PROPERTY_ServerName" '%s' "${DB_CONNECTION_PROPERTIES['ServerName']}"
+      printf -v "${prefix}_XA_CONNECTION_PROPERTY_PortNumber" '%s' "${DB_CONNECTION_PROPERTIES['PortNumber']}"
+      printf -v "${prefix}_XA_CONNECTION_PROPERTY_DatabaseName" '%s' "${DB_CONNECTION_PROPERTIES['DatabaseName']}"
+
+      # Set also the ${prefix}_DRIVER variable so the datasource is created
+      printf -v "${prefix}_DRIVER" '%s' "${db,,}"
+
+    done
+
+  fi
 
   inject_datasources
 }
@@ -39,7 +79,9 @@ function generate_datasource() {
   local validate="${13}"
   local url="${14}"
 
-  generate_datasource_common "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${10}" "${11}" "${12}" "${13}" "${14}"
+  # KEYCLOAK-10694 - Replace any request for MySQL DB driver with a request for the MariaDB one in RHEL-8 UBI minimal
+  driver=${driver//mysql/mariadb}
+  generate_datasource_common "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${driver}" "${11}" "${12}" "${13}" "${14}"
 
   if [ -z "$service_name" ]; then
     service_name="ExampleDS"

--- a/modules/sso/config/launch/setup/73/added/standalone-openshift.xml
+++ b/modules/sso/config/launch/setup/73/added/standalone-openshift.xml
@@ -130,8 +130,8 @@
                     <driver name="h2" module="com.h2database.h2">
                         <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
                     </driver>
-                    <driver name="mysql" module="com.mysql">
-                        <xa-datasource-class>com.mysql.jdbc.jdbc2.optional.MysqlXADataSource</xa-datasource-class>
+                    <driver name="mariadb" module="org.mariadb">
+                        <xa-datasource-class>org.mariadb.jdbc.MariaDbDataSource</xa-datasource-class>
                     </driver>
                     <driver name="postgresql" module="org.postgresql">
                         <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>

--- a/modules/sso/datasource/overrides/added/launch/datasource-common-overrides.sh
+++ b/modules/sso/datasource/overrides/added/launch/datasource-common-overrides.sh
@@ -1,0 +1,202 @@
+
+# Override the definition of the generate_external_datasource() routine from the
+# JBoss EAP 'os-eap-datasource' v1.0 module to add support for MariaDB driver
+
+function generate_external_datasource() {
+  local failed="false"
+
+  if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then
+    ds="<datasource jta=\"${jta}\" jndi-name=\"${jndi_name}\" pool-name=\"${pool_name}\" enabled=\"true\" use-java-context=\"true\" statistics-enabled=\"\${wildfly.datasources.statistics-enabled:\${wildfly.statistics-enabled:false}}\">
+          <connection-url>${url}</connection-url>
+          <driver>$driver</driver>"
+  else
+    ds=" <xa-datasource jndi-name=\"${jndi_name}\" pool-name=\"${pool_name}\" enabled=\"true\" use-java-context=\"true\" statistics-enabled=\"\${wildfly.datasources.statistics-enabled:\${wildfly.statistics-enabled:false}}\">"
+    local xa_props=$(compgen -v | grep -s "${prefix}_XA_CONNECTION_PROPERTY_")
+    # KEYCLOAK-10694 - Since previous RHEL-7 mysql-connector-java RPM was in RHEL-8 replaced with mariadb-java-client RPM, only drivers for MariaDB and
+    # PostgreSQL databases are installed by default. Any other driver needs to be installed using EAP Runtime Artifacts Datasources mechanism
+    if [ "$driver" != "mariadb" ] && [ "$driver" != "postgresql" ]; then
+      log_warning "Only datasource drivers for the MariaDB and PostgreSQL databases are available in the image by default. Datasource will not be configured. Please use the JBoss EAP Runtime Artifacts Datasources mechanism: https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/getting_started_with_jboss_eap_for_openshift_container_platform/index#Runtime-Artifacts to configure the ${driver} JDBC driver."
+      failed="true"
+    fi
+
+    if [ -z "$xa_props" ]; then
+      log_warning "At least one ${prefix}_XA_CONNECTION_PROPERTY_property for datasource ${service_name} is required. Datasource will not be configured."
+      failed="true"
+    else
+
+      for xa_prop in $(echo $xa_props); do
+        prop_name=$(echo "${xa_prop}" | sed -e "s/${prefix}_XA_CONNECTION_PROPERTY_//g")
+        prop_val=$(find_env $xa_prop)
+        if [ ! -z ${prop_val} ]; then
+          ds="$ds <xa-datasource-property name=\"${prop_name}\">${prop_val}</xa-datasource-property>"
+        fi
+      done
+
+      ds="$ds
+             <driver>${driver}</driver>"
+    fi
+
+    if [ -n "$tx_isolation" ]; then
+      ds="$ds
+             <transaction-isolation>$tx_isolation</transaction-isolation>"
+    fi
+  fi
+
+  if [ -n "$min_pool_size" ] || [ -n "$max_pool_size" ]; then
+    if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then
+       ds="$ds
+             <pool>"
+    else
+      ds="$ds
+             <xa-pool>"
+    fi
+
+    if [ -n "$min_pool_size" ]; then
+      ds="$ds
+             <min-pool-size>$min_pool_size</min-pool-size>"
+    fi
+    if [ -n "$max_pool_size" ]; then
+      ds="$ds
+             <max-pool-size>$max_pool_size</max-pool-size>"
+    fi
+    if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then
+      ds="$ds
+             </pool>"
+    else
+      ds="$ds
+             </xa-pool>"
+    fi
+  fi
+
+   ds="$ds
+         <security>
+           <user-name>${username}</user-name>
+           <password>${password}</password>
+         </security>"
+
+  if [ "$validate" == "true" ]; then
+
+    validation_conf="<validate-on-match>true</validate-on-match>
+                       <background-validation>false</background-validation>"
+
+    if [ $(find_env "${prefix}_BACKGROUND_VALIDATION" "false") == "true" ]; then
+
+        millis=$(find_env "${prefix}_BACKGROUND_VALIDATION_MILLIS" 10000)
+        validation_conf="<validate-on-match>false</validate-on-match>
+                           <background-validation>true</background-validation>
+                           <background-validation-millis>${millis}</background-validation-millis>"
+    fi
+
+    ds="$ds
+           <validation>
+             ${validation_conf}
+             <valid-connection-checker class-name=\"${checker}\"></valid-connection-checker>
+             <exception-sorter class-name=\"${sorter}\"></exception-sorter>
+           </validation>"
+  fi
+
+  if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then
+    ds="$ds
+           </datasource>"
+  else
+    ds="$ds
+           </xa-datasource>"
+  fi
+
+  if [ "$failed" == "true" ]; then
+    echo ""
+  else
+    echo $ds
+  fi
+}
+
+# Override the definition of the inject_tx_datasource() routine from the
+# JBoss EAP 'os-eap7-launch' v1.0 module to add support for the MariaDB driver
+
+function inject_tx_datasource() {
+  tx_backend=${TX_DATABASE_PREFIX_MAPPING}
+
+  if [ -n "${tx_backend}" ] ; then
+    service_name=${tx_backend%=*}
+    service=${service_name^^}
+    service=${service//-/_}
+    db=${service##*_}
+    prefix=${tx_backend#*=}
+
+    host=$(find_env "${service}_SERVICE_HOST")
+    port=$(find_env "${service}_SERVICE_PORT")
+
+    if [ -z $host ] || [ -z $port ]; then
+      log_warning "There is a problem with your service configuration!"
+      log_warning "You provided following database mapping (via TX_SERVICE_PREFIX_MAPPING environment variable): $tx_backend. To configure datasources we expect ${service}_SERVICE_HOST and ${service}_SERVICE_PORT to be set."
+      log_warning
+      log_warning "Current values:"
+      log_warning
+      log_warning "${service}_SERVICE_HOST: $host"
+      log_warning " ${service}_SERVICE_PORT: $port"
+      log_warning
+      log_warning "Please make sure you provided correct service name and prefix in the mapping. Additionally please check that you do not set portalIP to None in the $service_name service. Headless services are not supported at this time."
+      log_warning
+      log_warning "The ${db,,} datasource for $prefix service WILL NOT be configured."
+      return
+    fi
+
+    # Custom JNDI environment variable name format: [NAME]_[DATABASE_TYPE]_JNDI appended by ObjectStore
+    jndi=$(find_env "${prefix}_JNDI" "java:jboss/datasources/${service,,}")
+
+    # Database username environment variable name format: [NAME]_[DATABASE_TYPE]_USERNAME
+    username=$(find_env "${prefix}_USERNAME")
+
+    # Database password environment variable name format: [NAME]_[DATABASE_TYPE]_PASSWORD
+    password=$(find_env "${prefix}_PASSWORD")
+
+    # Database name environment variable name format: [NAME]_[DATABASE_TYPE]_DATABASE
+    database=$(find_env "${prefix}_DATABASE")
+
+    if [ -z $jndi ] || [ -z $username ] || [ -z $password ] || [ -z $database ]; then
+      log_warning "Ooops, there is a problem with the ${db,,} datasource!"
+      log_warning "In order to configure ${db,,} transactional datasource for $prefix service you need to provide following environment variables: ${prefix}_USERNAME, ${prefix}_PASSWORD, ${prefix}_DATABASE."
+      log_warning
+      log_warning "Current values:"
+      log_warning
+      log_warning "${prefix}_USERNAME: $username"
+      log_warning "${prefix}_PASSWORD: $password"
+      log_warning "${prefix}_DATABASE: $database"
+      log_warning
+      log_warning "The ${db,,} datasource for $prefix service WILL NOT be configured."
+      db="ignore"
+    fi
+
+    # Transaction isolation level environment variable name format: [NAME]_[DATABASE_TYPE]_TX_ISOLATION
+    tx_isolation=$(find_env "${prefix}_TX_ISOLATION")
+
+    # min pool size environment variable name format: [NAME]_[DATABASE_TYPE]_MIN_POOL_SIZE
+    min_pool_size=$(find_env "${prefix}_MIN_POOL_SIZE")
+
+    # max pool size environment variable name format: [NAME]_[DATABASE_TYPE]_MAX_POOL_SIZE
+    max_pool_size=$(find_env "${prefix}_MAX_POOL_SIZE")
+
+    case "$db" in
+      "MARIADB"|"MYSQL")
+        # KEYCLOAK-10694 - Replace any request for MySQL DB driver with a request for MariaDB one in RHEL-8 UBI minimal
+        driver="mariadb"
+        service="${service//MYSQL/MARIADB}"
+        datasource="$(generate_tx_datasource ${service,,} $jndi $username $password $host $port $database $driver)\n"
+        inject_jdbc_store "${jndi}ObjectStore"
+        ;;
+      "POSTGRESQL")
+        driver="postgresql"
+        datasource="$(generate_tx_datasource ${service,,} $jndi $username $password $host $port $database $driver)\n"
+        inject_jdbc_store "${jndi}ObjectStore"
+        ;;
+      *)
+        datasource=""
+        ;;
+    esac
+    echo ${datasource} | sed ':a;N;$!ba;s|\n|\\n|g'
+  else
+    if [ -n "$JDBC_STORE_JNDI_NAME" ]; then
+      inject_jdbc_store "${JDBC_STORE_JNDI_NAME}"
+    fi
+  fi
+}

--- a/modules/sso/datasource/overrides/configure.sh
+++ b/modules/sso/datasource/overrides/configure.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Red Hat Single Sign-On datasource refinements script package
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+
+mkdir -p ${JBOSS_HOME}/bin/launch
+cp -r ${ADDED_DIR}/launch/* ${JBOSS_HOME}/bin/launch

--- a/modules/sso/datasource/overrides/module.yaml
+++ b/modules/sso/datasource/overrides/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: sso.datasource.overrides
+version: '1.0'
+description: "Red Hat Single Sign-On datasource refinements module to override the definition(s) of certain TX and XA datasource manipulation routines, as defined in ['os-eap7-launch/1.0'](https://github.com/jboss-container-images/jboss-eap-modules/tree/master/os-eap7-launch) and ['os-eap-datasource/1.0'](https://github.com/jboss-container-images/jboss-eap-modules/tree/master/os-eap-datasource/1.0) modules."
+execute:
+- script: configure.sh
+  user: '185'

--- a/modules/sso/db/drivers/added/modules/system/layers/openshift/org/mariadb/main/module.xml
+++ b/modules/sso/db/drivers/added/modules/system/layers/openshift/org/mariadb/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="org.mariadb">
+  <resources>
+    <resource-root path="mariadb-java-client.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/modules/sso/db/drivers/added/modules/system/layers/openshift/org/postgresql/main/module.xml
+++ b/modules/sso/db/drivers/added/modules/system/layers/openshift/org/postgresql/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="org.postgresql">
+  <resources>
+    <resource-root path="postgresql-jdbc.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/modules/sso/db/drivers/configure.sh
+++ b/modules/sso/db/drivers/configure.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Link DB drivers, provided by RPM packages, into the "openshift" layer
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+
+function link {
+  mkdir -p $(dirname $2)
+  ln -s $1 $2
+}
+
+link /usr/lib/java/mariadb-java-client.jar $JBOSS_HOME/modules/system/layers/openshift/org/mariadb/main/mariadb-java-client.jar
+link /usr/share/java/postgresql-jdbc.jar $JBOSS_HOME/modules/system/layers/openshift/org/postgresql/main/postgresql-jdbc.jar
+
+# module definitions for MariaDB and PostgreSQL
+# Remove any existing destination files first (which might be symlinks)
+cp -rp --remove-destination "$ADDED_DIR/modules" "$JBOSS_HOME/"

--- a/modules/sso/db/drivers/module.yaml
+++ b/modules/sso/db/drivers/module.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+name: sso.db.drivers
+version: '1.0'
+description: Legacy sso.db.drivers script package, derived from [EAP_722 release of os-eap-db-drivers package for JBoss EAP for OpenShift image](https://github.com/jboss-container-images/jboss-eap-modules/tree/c910472e03d6ce281654f171d56c227d493cb900/os-eap-db-drivers). Compared to the original version, the MongoDB database driver was intentionally excluded, and the MySQL database driver was replaced with the MariaDB one.
+execute:
+- script: configure.sh
+  user: '185'
+packages:
+      install:
+          - postgresql-jdbc
+          - mariadb-java-client

--- a/override-dev.yaml
+++ b/override-dev.yaml
@@ -1,4 +1,0 @@
-osbs:
-      repository:
-            name: containers/redhat-sso-7
-            branch: jb-sso-cd-openshift-dev-rhel-7

--- a/overrides/README.adoc
+++ b/overrides/README.adoc
@@ -1,0 +1,3 @@
+# Various link:https://cekit.io/[CEKit] Overrides modules for the Red Hat Single Sign-On 7 OpenShift container image
+
+link:https://cekit.io/[CEKit] provides link:https://docs.cekit.io/en/latest/handbook/overrides.html[Overrides] feature to customize image builds (e.g. use different base image, include different version of specific libraries etc.). It's even possible to link:https://docs.cekit.io/en/latest/handbook/overrides.html#overrides-chaining[chain multiple overrides] to combine the requests together.

--- a/overrides/osbs-dev-branch-overrides.yaml
+++ b/overrides/osbs-dev-branch-overrides.yaml
@@ -3,4 +3,4 @@
 osbs:
       repository:
             name: containers/redhat-sso-7
-            branch: jb-sso-cd-openshift-dev-rhel-7
+            branch: jb-sso-cd-openshift-dev-rhel8

--- a/overrides/osbs-dev-branch-overrides.yaml
+++ b/overrides/osbs-dev-branch-overrides.yaml
@@ -1,0 +1,6 @@
+# CEKit Overrides module to use the -dev branch for the Red Hat Single Sign-On 7 OpenShift container image in OSBS
+# See README.adoc and https://docs.cekit.io/en/latest/handbook/overrides.html for details
+osbs:
+      repository:
+            name: containers/redhat-sso-7
+            branch: jb-sso-cd-openshift-dev-rhel-7


### PR DESCRIPTION
    [KEYCLOAK-10694] [KEYCLOAK-10103] RHEL-8 UBI minimal / EAP CD 17 modules / CEKit 3.x support
    [KEYCLOAK-10124] Define RHEL-8 content set for the Red Hat Single Sign-On 7 OpenShift container image
    
    * Start using EAP modules for EAP CD 17 / JDK 11 / RHEL-8 UBI support:
      https://github.com/jboss-container-images/jboss-eap-7-openshift-image/commit/cde917a051b65dd748f72ec2b9ab2d130158132f#diff-b56ad46b43eb108be045b7ad559c32b6
      and drop the use of deprecated EAP modules,
    
    * Update CCT and EAP modules to 'master' to pick most fresh
      RHEL-8 UBI / CEKit 3.x changes. Also default to 'microdnf'
      package manager and define RHEL-8 content set,
    
    * Introduce 'overrides' subdirectory as a common location to
      keep examples of various CEKit Overrides files,
    
    * Introduce 'backward-compatibility' subdirectory as a common
      location to keep various CEKit image descriptor files, that
      need to be archived each time a major, backward-incompatible
      change is introduced to CEKit. Archive image file descriptor,
      used to build the image:
      * Using CEKit 2.x,
      * Use yum as the package manager, when the parent image was
        based on RHEL-7 image,
      * Use JBoss EAP modules of version 'CD16' (or earlier) in
        the image
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

--

    [KEYCLOAK-10556] Inherit the original 'os-eap-db-drivers' module
    implementation from EAP_722 release of jboss-eap-modules repository:
    
      https://github.com/jboss-container-images/jboss-eap-modules/tree/c910472e03d6ce281654f171d56c227d493cb900/os-eap-db-drivers
    
    into new 'sso.db.drivers' RH-SSO module.
    
    Also:
    * Drop the MongoDB database driver, and
    * Replace MySQL database driver with the MariaDB one
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

--

    [KEYCLOAK-10858] Address RH-SSO pod launch failures, leading
    to WFLYJCA0069 error with certain combination of DB_SERVICE_PREFIX_MAPPING /
    ${prefix}_DRIVER variables provided to the pod
    
    * Derive XA connection properties & DB driver from the value of
      DB_SERVICE_PREFIX_MAPPING environment variable if provided, to
      avoid this error
    
    [KEYCLOAK-10694] Use MariaDB client instead of the MySQL one in
    RH-SSO OpenShift image based on RHEL-8 UBI minimal image:
    
    * Modify standalone-openshift.xml so MariaDB JDBC driver can be used
      as a functional replacement of the MySQL one,
    
    * Override definitions of certain TX & XA datasource creation /
      processing routines from common JBoss EAP modules
      ('os-eap-datasource' and 'os-eap7-launch' one) to:
    
      -- Replace any request for MySQL DB driver with a request for the MariaDB
         one,
    
      -- Forbid JDBC requests (via DB_SERVICE_PREFIX_MAPPING or ${prefix}_DRIVER
         environment variables) to use of any other DB drivers, than just MariaDB
         and PostgreSQL ones. Instruct users to install other JDBC drivers via
         the usual JBoss EAP Runtime Artifacts Datasources mechanism
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
--


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
