### PR TITLE
[KEYCLOAK-10694] Unmask 'python' alternatives alias & point it to Python 3 binary

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -95,6 +95,8 @@ modules:
             version: '1.0'
           - name: sso.datasource.overrides
             version: '1.0'
+          - name: sso.python
+            version: '3'
           # Other common modules from the main CE cct_module repository
           - name: openshift-layer
           - name: openshift-passwd
@@ -102,11 +104,6 @@ modules:
           - name: os-logging
 packages:
       manager: microdnf
-      install:
-      # RHEL-8 UBI Minimal image configures python3 alternatives right by install,
-      # thus another 'alternatives --set python /usr/bin/python3' call fails
-      # Instead of using 'os-eap-python/3.6' module just install 'python36' RPM directly
-          - python36
       content_sets:
             x86_64:
                 - rhel-8-for-x86_64-baseos-rpms

--- a/modules/sso/python/3/configure.sh
+++ b/modules/sso/python/3/configure.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Red Hat Single Sign-On module to install & configure Python 3 binary
+set -e
+
+# Unmask 'python' alternatives alias & point it to Python 3 binary
+alternatives --remove python /usr/libexec/no-python && alternatives --set python /usr/bin/python3

--- a/modules/sso/python/3/module.yaml
+++ b/modules/sso/python/3/module.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+name: sso.python
+version: '3'
+description: "Red Hat Single Sign-On module to install & configure Python 3, which is a requirement for the JBoss EAP 'os.eap.probes/2.0' module."
+execute:
+- script: configure.sh
+packages:
+      install:
+          - python36


### PR DESCRIPTION

    [KEYCLOAK-10694] Unmask 'python' alternatives alias & point it to Python 3 binary
    
    The 'python' Python 3.6 alternatives alias is masked with 'python' alternatives
    alias pointing to '/usr/libexec/no-python' in the default image install:

    [root@002dc9f8cbae ~]# alternatives --display python    
    python - status is auto.
     link currently points to /usr/libexec/no-python
    /usr/libexec/no-python - priority 404
     slave unversioned-python: (null)
     slave unversioned-python-man: /usr/share/man/man1/unversioned-python.1.gz
    /usr/bin/python3 - priority 300
     slave unversioned-python: /usr/bin/python3
     slave unversioned-python-man: /usr/share/man/man1/python3.1.gz
    Current `best' version is /usr/libexec/no-python.
    
    Therefore unmask it, and point 'python' alternatives alias back to Python 3 binary
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
