### PR TITLE
KEYCLOAK-11171 Support more than 1 CA

### DIFF
--- a/docs/templates/sso-cd-https.adoc
+++ b/docs/templates/sso-cd-https.adoc
@@ -224,3 +224,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso-cd-mysql-persistent.adoc
+++ b/docs/templates/sso-cd-mysql-persistent.adoc
@@ -278,3 +278,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso-cd-mysql.adoc
+++ b/docs/templates/sso-cd-mysql.adoc
@@ -263,3 +263,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso-cd-postgresql-persistent.adoc
+++ b/docs/templates/sso-cd-postgresql-persistent.adoc
@@ -273,3 +273,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso-cd-postgresql.adoc
+++ b/docs/templates/sso-cd-postgresql.adoc
@@ -258,3 +258,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso-cd-x509-https.adoc
+++ b/docs/templates/sso-cd-x509-https.adoc
@@ -166,7 +166,7 @@ for more information.
 |`JGROUPS_PING_PROTOCOL` | -- | openshift.DNS_PING
 |`OPENSHIFT_DNS_PING_SERVICE_NAME` | -- | `${APPLICATION_NAME}-ping`
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
-|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
+|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server admininistrator password | `${SSO_ADMIN_PASSWORD}`
@@ -194,3 +194,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso-cd-x509-mysql-persistent.adoc
+++ b/docs/templates/sso-cd-x509-mysql-persistent.adoc
@@ -196,7 +196,7 @@ for more information.
 |`JGROUPS_PING_PROTOCOL` | -- | openshift.DNS_PING
 |`OPENSHIFT_DNS_PING_SERVICE_NAME` | -- | `${APPLICATION_NAME}-ping`
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
-|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
+|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
@@ -248,3 +248,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso-cd-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso-cd-x509-postgresql-persistent.adoc
@@ -193,7 +193,7 @@ for more information.
 |`JGROUPS_PING_PROTOCOL` | -- | openshift.DNS_PING
 |`OPENSHIFT_DNS_PING_SERVICE_NAME` | -- | `${APPLICATION_NAME}-ping`
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
-|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
+|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
@@ -243,3 +243,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/template.adoc.in
+++ b/template.adoc.in
@@ -252,3 +252,14 @@ oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-acco
 ====
 {/clustering}
 {/objects}
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/templates/sso-cd-x509-https.json
+++ b/templates/sso-cd-x509-https.json
@@ -328,7 +328,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",

--- a/templates/sso-cd-x509-mysql-persistent.json
+++ b/templates/sso-cd-x509-mysql-persistent.json
@@ -451,7 +451,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",

--- a/templates/sso-cd-x509-postgresql-persistent.json
+++ b/templates/sso-cd-x509-postgresql-persistent.json
@@ -433,7 +433,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-11171

Most of the work has already been done by @iankko in [KEYCLOAK-8129](https://issues.jboss.org/browse/KEYCLOAK-8129). This PR introduces support for multiple CAs in `X509_CA_BUNDLE` variable.

This also needs to go into `7.3.4` release branch. I'm not sure what the workflow is, shall I cherry-pick it somewhere?