### PR TITLE
[KEYCLOAK-11099] Update to RH-SSO 7.3.4. Bump cct_module version to '0.37.0' and jboss-eap-modules version to 'EAP_724_CR2'

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -55,11 +55,11 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.35.1
+                  ref: 0.37.0
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_723_CR2
+                  ref: EAP_724_CR2
           - name: sso73_modules
             path: modules
       install:
@@ -67,36 +67,65 @@ modules:
           # you first verified the image with changed order still works correctly
           # Common modules from the main CE cct_module repository
           - name: dynamic-resources
+            version: '1.0'
           - name: s2i-common
+            version: '1.0'
           - name: java-alternatives
+            version: '1.0'
           - name: os-eap7-openshift
+            version: '1.0'
           - name: os-eap-s2i
+            version: '1.0'
           - name: os-java-jolokia
+            version: '1.0' 
           - name: jboss.eap.cd.jolokia
+            version: '1.0'
           - name: os-eap7-openshift
+            version: '1.0'
           - name: jboss.eap.cd.openshift.modules
+            version: '1.0'
           - name: os-eap7-ping
+            version: '1.0'
           - name: os-java-run
+            version: '1.0'
           - name: os-eap-launch
+            version: '1.0'
           - name: os-eap7-launch
+            version: '1.0' 
           - name: jboss.eap.cd.logging
+            version: '1.0'
           - name: jboss.eap.config.jgroups
+            version: '1.0'
           - name: jboss.eap.config.elytron
+            version: '1.0'
           - name: os-eap-probes
+            version: '1.0' 
           - name: jboss-maven
+            version: '1.0'
           - name: os-java-hawkular
+            version: '1.0'
           - name: os-eap70-hawkular
+            version: '1.0'
           - name: os-eap-hawkular
+            version: '1.0'
           - name: os-eap-deployment-scanner
+            version: '1.0'
           - name: os-eap-extensions
+            version: '1.0'
           # RH-SSO 7.3 product specific modules from modules/ path in this repository
           - name: sso.config.launch.setup.73
+            version: '1.0'
           - name: sso.db.drivers
+            version: '1.0'
           # Other common modules from the main CE cct_module repository
           - name: openshift-layer
+            version: '1.0'
           - name: openshift-passwd
+            version: '1.0'
           - name: keycloak-layer
+            version: '1.0'
           - name: os-logging
+            version: '1.0'
 packages:
       repositories:
           - jboss-os

--- a/templates/sso73-https.json
+++ b/templates/sso73-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-https",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-image-stream.json
+++ b/templates/sso73-image-stream.json
@@ -18,11 +18,11 @@
                     "description": "Red Hat Single Sign-On 7.3",
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.3",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.3.3.GA"
+                    "version": "7.3.4.GA"
                 }
             },
             "labels": {
-                "rhsso": "7.3.3.GA"
+                "rhsso": "7.3.4.GA"
             },
             "spec": {
                 "tags": [

--- a/templates/sso73-mysql-persistent.json
+++ b/templates/sso73-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-mysql-persistent",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-mysql.json
+++ b/templates/sso73-mysql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-mysql",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-postgresql-persistent.json
+++ b/templates/sso73-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-postgresql-persistent",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-postgresql.json
+++ b/templates/sso73-postgresql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-postgresql",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso73-x509-https.json
+++ b/templates/sso73-x509-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-x509-https",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso73-x509-mysql-persistent.json
+++ b/templates/sso73-x509-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-x509-mysql-persistent",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso73-x509-postgresql-persistent.json
+++ b/templates/sso73-x509-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.3.3.GA",
+            "version": "7.3.4.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso73-x509-postgresql-persistent",
-        "rhsso": "7.3.3.GA"
+        "rhsso": "7.3.4.GA"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [


### PR DESCRIPTION

Also, since explicit is better than implicit, for each
module from cct_modules & JBoss EAP modules specify version
of the module, that should be used

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
