### PR TITLE
allowing wildcard support for ca bundle

### DIFF
--- a/docs/templates/sso73-https.adoc
+++ b/docs/templates/sso73-https.adoc
@@ -224,3 +224,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso73-mysql-persistent.adoc
+++ b/docs/templates/sso73-mysql-persistent.adoc
@@ -278,3 +278,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso73-mysql.adoc
+++ b/docs/templates/sso73-mysql.adoc
@@ -263,3 +263,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso73-postgresql-persistent.adoc
+++ b/docs/templates/sso73-postgresql-persistent.adoc
@@ -273,3 +273,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso73-postgresql.adoc
+++ b/docs/templates/sso73-postgresql.adoc
@@ -258,3 +258,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso73-x509-https.adoc
+++ b/docs/templates/sso73-x509-https.adoc
@@ -166,7 +166,7 @@ for more information.
 |`JGROUPS_PING_PROTOCOL` | -- | openshift.DNS_PING
 |`OPENSHIFT_DNS_PING_SERVICE_NAME` | -- | `${APPLICATION_NAME}-ping`
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
-|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
+|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server admininistrator password | `${SSO_ADMIN_PASSWORD}`
@@ -194,3 +194,14 @@ for more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso73-x509-mysql-persistent.adoc
+++ b/docs/templates/sso73-x509-mysql-persistent.adoc
@@ -196,7 +196,7 @@ for more information.
 |`JGROUPS_PING_PROTOCOL` | -- | openshift.DNS_PING
 |`OPENSHIFT_DNS_PING_SERVICE_NAME` | -- | `${APPLICATION_NAME}-ping`
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
-|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
+|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
@@ -248,3 +248,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/docs/templates/sso73-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso73-x509-postgresql-persistent.adoc
@@ -193,7 +193,7 @@ for more information.
 |`JGROUPS_PING_PROTOCOL` | -- | openshift.DNS_PING
 |`OPENSHIFT_DNS_PING_SERVICE_NAME` | -- | `${APPLICATION_NAME}-ping`
 |`OPENSHIFT_DNS_PING_SERVICE_PORT` | -- | 8888
-|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
+|X509_CA_BUNDLE | -- | `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 |`JGROUPS_CLUSTER_PASSWORD` | The password for the JGroups cluster. | `${JGROUPS_CLUSTER_PASSWORD}`
 |`SSO_ADMIN_USERNAME` | RH-SSO Server administrator username | `${SSO_ADMIN_USERNAME}`
 |`SSO_ADMIN_PASSWORD` | RH-SSO Server administrator password | `${SSO_ADMIN_PASSWORD}`
@@ -243,3 +243,14 @@ more information.
 
 
 
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/modules/sso/config/launch/setup/73/added/launch/openshift-x509.sh
+++ b/modules/sso/config/launch/setup/73/added/launch/openshift-x509.sh
@@ -84,6 +84,7 @@ function autogenerate_keystores() {
   local JKS_TRUSTSTORE_FILE="truststore.jks"
   local JKS_TRUSTSTORE_PATH="${KEYSTORES_STORAGE}/${JKS_TRUSTSTORE_FILE}"
   local PASSWORD=$(openssl rand -base64 32)
+  local TEMPORARY_CERTIFICATE="temporary_ca.crt"
   if [ -n "${X509_CA_BUNDLE}" ]; then
     log_info "Creating RH-SSO truststore.."
     # We use cat here, so that users could specify multiple CA Bundles using space or even wildcard:
@@ -91,7 +92,7 @@ function autogenerate_keystores() {
     # Note, that there is no quotes here, that's intentional. Once can use spaces in the $X509_CA_BUNDLE like this:
     # X509_CA_BUNDLE=/ca.crt /ca2.crt
     cat ${X509_CA_BUNDLE} > ${TEMPORARY_CERTIFICATE}
-    csplit -s -z -f crt- "${X509_CA_BUNDLE}" "${X509_CRT_DELIMITER}" '{*}'
+    csplit -s -z -f crt- "${TEMPORARY_CERTIFICATE}" "${X509_CRT_DELIMITER}" '{*}'
     for CERT_FILE in crt-*; do
       "$KEYTOOL" -import -noprompt -keystore "${JKS_TRUSTSTORE_PATH}" -file "${CERT_FILE}" \
       -storepass "${PASSWORD}" -alias "service-${CERT_FILE}" >& /dev/null

--- a/modules/sso/config/launch/setup/73/added/launch/openshift-x509.sh
+++ b/modules/sso/config/launch/setup/73/added/launch/openshift-x509.sh
@@ -83,9 +83,10 @@ function autogenerate_keystores() {
   local -r X509_CRT_DELIMITER="/-----BEGIN CERTIFICATE-----/"
   local JKS_TRUSTSTORE_FILE="truststore.jks"
   local JKS_TRUSTSTORE_PATH="${KEYSTORES_STORAGE}/${JKS_TRUSTSTORE_FILE}"
-  local PASSWORD=$(openssl rand -base64 32)
+  local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
   local TEMPORARY_CERTIFICATE="temporary_ca.crt"
   if [ -n "${X509_CA_BUNDLE}" ]; then
+   pushd /tmp >& /dev/null
     log_info "Creating RH-SSO truststore.."
     # We use cat here, so that users could specify multiple CA Bundles using space or even wildcard:
     # X509_CA_BUNDLE=/var/run/secrets/kubernetes.io/serviceaccount/*.crt
@@ -125,5 +126,6 @@ function autogenerate_keystores() {
     SSO_TRUSTSTORE_PASSWORD="${PASSWORD}"
     SSO_TRUSTSTORE_DIR="${KEYSTORES_STORAGE}"
     SSO_TRUSTSTORE="${JKS_TRUSTSTORE_FILE}"
+    popd >& /dev/null
   fi
 }

--- a/modules/sso/config/launch/setup/73/added/launch/openshift-x509.sh
+++ b/modules/sso/config/launch/setup/73/added/launch/openshift-x509.sh
@@ -102,7 +102,7 @@ function autogenerate_keystores() {
     fi
 
     # Import existing system CA certificates into the newly generated truststore
-    local SYSTEM_CACERTS="$(readlink -e $(dirname $(readlinkgit -e $(which "$KEYTOOL")))"/../lib/security/cacerts")"
+    local SYSTEM_CACERTS="$(readlink -e $(dirname $(readlink -e $(which "$KEYTOOL")))"/../lib/security/cacerts")"
     if [ ! -f "$SYSTEM_CACERTS" -a -f "$(readlink -e $(dirname $(readlink -e $(which "$KEYTOOL")))"/../jre/lib/security/cacerts")" ]; then
         SYSTEM_CACERTS="$(readlink -e $(dirname $(readlink -e $(which "$KEYTOOL")))"/../jre/lib/security/cacerts")"
     fi

--- a/template.adoc.in
+++ b/template.adoc.in
@@ -252,3 +252,14 @@ oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-acco
 ====
 {/clustering}
 {/objects}
+
+[[tls]]
+== TLS/SSL configuration
+
+Red Hat Single Sign-On server can be configured to use TLS for handling incoming connections (also known as Key Store) and outgoing connections (also known as Trust Store). The configuration uses an automated script to convert a key or a certificate from PEM format into JKS, which is then consumed by Red Hat Single Sign-On.
+
+The Key Store configuration requires a secret (or a volume), containing the key in PEM format, mounted at `/etc/x509/https`. The name of the file that holds the key is `tls.key` by default. Typically, a key is link:https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets[created by OpenShift and mounted as a secret.] The `sso-*-x509-https.json` template contains a example of such a configuration.
+
+The Trust Store configuration uses certificates in PEM format. They should be mounted somewhere in the Pod and `X509_CA_BUNDLE` variable should point to them. A typical example is using the set of CA certificates, as provided by OpenShift - `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. The `X509_CA_BUNDLE` variable might be configured to point to a custom file system path within the Pod, containing the set of CA certificates to use. The space (` `) character is used as a separator for specifying multiple CA bundles.
+
+TIP: With the current implementation it is possible to use `X509_CA_BUNDLE` along with `SSO_TRUSTSTORE_*`. However, the current implementation favors the `X509_CA_BUNDLE` variable and in some cases, `SSO_TRUSTSTORE_*` might be ignored. This behavior is implementation dependent and may change in the future.

--- a/templates/sso73-x509-https.json
+++ b/templates/sso73-x509-https.json
@@ -328,7 +328,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",

--- a/templates/sso73-x509-mysql-persistent.json
+++ b/templates/sso73-x509-mysql-persistent.json
@@ -451,7 +451,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",

--- a/templates/sso73-x509-postgresql-persistent.json
+++ b/templates/sso73-x509-postgresql-persistent.json
@@ -433,7 +433,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",


### PR DESCRIPTION
Signed-off-by: akoserwa <akoserwa@redhat.com>

Reference: https://github.com/keycloak/keycloak-containers/blob/master/server/tools/x509.sh#L71

Adding wildcard support for ca cert configuration. This will allow configuration support for both Vanilla k8 & Openshift as the path varies `var/run/secrets/kubernetes.io/serviceaccount/ca.crt` (K8s) & `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` (Openshift). 

This will support the configuration for keycloak-operator. As we have verified the operator deployment for both K8s and Openshift.
https://github.com/keycloak/keycloak-operator/blob/master/pkg/model/keycloak_deployment.go#L124
After this request merged it will allow configuring for this: 
https://github.com/keycloak/keycloak-operator/blob/master/pkg/model/rhsso_deployment.go#L101

- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
