### PR TITLE
[KEYCLOAK-12905] [KEYCLOAK-12920] Fixes

### DIFF
--- a/docs/templates/sso73-postgresql-persistent.adoc
+++ b/docs/templates/sso73-postgresql-persistent.adoc
@@ -56,7 +56,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE` | `SSO_TRUSTSTORE` | The name of the truststore file within the secret (e.g. truststore.jks) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 9.5 | True
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 10 | True
 |`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
 |=======================================================================
 

--- a/docs/templates/sso73-postgresql.adoc
+++ b/docs/templates/sso73-postgresql.adoc
@@ -55,7 +55,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE` | `SSO_TRUSTSTORE` | The name of the truststore file within the secret (e.g. truststore.jks) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 9.5 | True
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 10 | True
 |`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
 |=======================================================================
 

--- a/docs/templates/sso73-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso73-x509-postgresql-persistent.adoc
@@ -42,7 +42,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_REALM` | `SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}` | False
 |`SSO_SERVICE_USERNAME` | `SSO_SERVICE_USERNAME` | The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm. | `${SSO_SERVICE_USERNAME}` | False
 |`SSO_SERVICE_PASSWORD` | `SSO_SERVICE_PASSWORD` | The password for the RH-SSO service user. | `${SSO_SERVICE_PASSWORD}` | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream.  Typically, this aligns with the major.minor version of PostgreSQL. | 9.5 | True
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream.  Typically, this aligns with the major.minor version of PostgreSQL. | 10 | True
 |`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
 |=======================================================================
 

--- a/templates/sso73-mysql-persistent.json
+++ b/templates/sso73-mysql-persistent.json
@@ -757,16 +757,20 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "exec": {
                                         "command": [ "/bin/sh", "-i", "-c",
                                             "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
                                     }
                                 },
                                 "livenessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 30,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "tcpSocket": {
                                         "port": 3306
                                     }

--- a/templates/sso73-postgresql-persistent.json
+++ b/templates/sso73-postgresql-persistent.json
@@ -739,15 +739,19 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "exec": {
                                         "command": [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
                                     }
                                 },
                                 "livenessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 30,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "tcpSocket": {
                                         "port": 5432
                                     }

--- a/templates/sso73-postgresql-persistent.json
+++ b/templates/sso73-postgresql-persistent.json
@@ -256,7 +256,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "value": "9.5",
+            "value": "10",
             "required": true
         },
         {

--- a/templates/sso73-postgresql.json
+++ b/templates/sso73-postgresql.json
@@ -249,7 +249,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "value": "9.5",
+            "value": "10",
             "required": true
         },
         {

--- a/templates/sso73-x509-mysql-persistent.json
+++ b/templates/sso73-x509-mysql-persistent.json
@@ -556,16 +556,20 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "exec": {
                                         "command": [ "/bin/sh", "-i", "-c",
                                             "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
                                     }
                                 },
                                 "livenessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 30,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "tcpSocket": {
                                         "port": 3306
                                     }

--- a/templates/sso73-x509-postgresql-persistent.json
+++ b/templates/sso73-x509-postgresql-persistent.json
@@ -158,7 +158,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "value": "9.5",
+            "value": "10",
             "required": true
         },
         {

--- a/templates/sso73-x509-postgresql-persistent.json
+++ b/templates/sso73-x509-postgresql-persistent.json
@@ -538,15 +538,19 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "exec": {
                                         "command": [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
                                     }
                                 },
                                 "livenessProbe": {
-                                    "timeoutSeconds": 1,
-                                    "initialDelaySeconds": 30,
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "failureThreshold": 3,
                                     "tcpSocket": {
                                         "port": 5432
                                     }


### PR DESCRIPTION
<hr/>

    [KEYCLOAK-12905] PostgreSQL templates: Update PostgreSQL image stream tag version to "10"
    
    Utilize PostgreSQL of version v10 by default, when deploying the Red Hat Single Sign-On 7.3
    for OpenShift image from PostgreSQL templates
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<hr/>

    [KEYCLOAK-12920] Persistent templates: Adjust "timeoutSeconds" and "initialDelaySeconds"
    to prevent readiness / liveness probe to end up DB pod lifecycle prematurely
    (yet before the DB server has had chance properly to initialize)
    
    Customize:
    * "timeoutSeconds" to 10 and
    * "initialDelaySeconds" to 90
    
    and also specify:
    * "successThreshold:" to 1 and
    * "failureThreshold" to 3
    
    on readiness and liveness probes in persistent templates to avoid readiness / liveness probe
    to bail out DB pod lifecycle prematurely due to:
    * "Inappropriate ioctl for device" event (case of MySQL probes), or
    * Issues like https://github.com/sclorg/postgresql-container/issues/309 (case of PostgreSQL probes)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<hr/>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
