### PR TITLE
[KEYCLOAK-13574] Return the basic Jolokia module back to the image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -78,6 +78,9 @@ modules:
             version: '1.0'
           - name: os-eap-s2i
             version: '1.0'
+          # KEYCLOAK-13574 Basic Jolokia module is a hard requirement for the CD Jolokia module
+          - name: jboss.container.jolokia.bash
+            version: '1.0'
           - name: jboss.eap.cd.jolokia
             version: '1.0'
           - name: jboss.eap.cd.openshift.modules


### PR DESCRIPTION
    [KEYCLOAK-13574] Return the basic Jolokia module back to the image
    
    Return the basic Jolokia module, which is a hard requirement for the
    configuration done within the EAP CD Jolokia module, back to the
    Red Hat Single Sign-On 7.3 for OpenShift image
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

P.S.: Intentionally didn't upgrade the `cct_module` version to the latest [`0.41.0` tag](https://github.com/jboss-openshift/cct_module/releases/tag/0.41.0), because there was large refactoring of the Jolokia & Maven modules done in that tag, and now `os-eap-s2i` module inclusion / loading fails due to some missing `*.bash` module. More on this later (but for now the Jolokia functionality will work again for the Red Hat Single Sign-On 7.3 for OpenShift image).



Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
