### PR TITLE
Updated content sets for s390x and ppc64le

### DIFF
--- a/content_sets.yaml
+++ b/content_sets.yaml
@@ -4,9 +4,11 @@ aarch64:
 ppc64le:
 - rhel-8-for-ppc64le-baseos-rpms
 - rhel-8-for-ppc64le-appstream-rpms
+- openj9-1-for-rhel-8-ppc64le-rpms
 s390x:
 - rhel-8-for-s390x-baseos-rpms
 - rhel-8-for-s390x-appstream-rpms
+- openj9-1-for-rhel-8-s390x-rpms
 x86_64:
 - rhel-8-for-x86_64-baseos-rpms
 - rhel-8-for-x86_64-appstream-rpms


### PR DESCRIPTION
Adding openj9 rpms to fix the CVP content_sets failure for s390x and ppc64le.

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com
