### PR TITLE
Updated 'public_url' key to fix KeyError

### DIFF
--- a/get-artifacts.py
+++ b/get-artifacts.py
@@ -29,4 +29,4 @@ def is_matching_artifact(a):
 for a in build_artifacts:
     b = is_matching_artifact(a)
     if b:
-        print("- target: %s\n  name: %s\n  md5: %s\n  url: %s" % (b[0], b[0], a['md5'], a['public_url']))
+        print("- target: %s\n  name: %s\n  md5: %s\n  url: %s" % (b[0], b[0], a['md5'], a['publicUrl']))


### PR DESCRIPTION
A Key error was encountered while getting the list of build artifacts using the bacon-pnc cli. For public URL, the JSON output generates the key name as 'publicUrl' instead of 'public_url'. This PR will fix the key error related to the current key name in the get-artifacts.py script.

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com
