### PR TITLE
[KEYCLOAK-13585] Prevent CVE-2020-10695 by using nss_wrapper approach

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -108,7 +108,6 @@ modules:
 
           # Other common modules from the main CE cct_module repository
           - name: openshift-layer
-          - name: openshift-passwd
           - name: keycloak-layer
 
           # This needs to be the very last, after all updates to standalone-openshift.xml have been done. See eg. https://access.redhat.com/solutions/3402171 for use

--- a/modules/sso/config/launch/setup/74/added/launch/openshift-common.sh
+++ b/modules/sso/config/launch/setup/74/added/launch/openshift-common.sh
@@ -26,7 +26,6 @@ IMPORT_REALM_FILE=$JBOSS_HOME/standalone/configuration/import-realm.json
 
 CONFIGURE_SCRIPTS=(
   $JBOSS_HOME/bin/launch/configure_extensions.sh
-  $JBOSS_HOME/bin/launch/passwd.sh
   $JBOSS_HOME/bin/launch/datasource.sh
   $JBOSS_HOME/bin/launch/resource-adapter.sh
   $JBOSS_HOME/bin/launch/admin.sh

--- a/modules/sso/config/launch/setup/74/added/openshift-launch.sh
+++ b/modules/sso/config/launch/setup/74/added/openshift-launch.sh
@@ -44,6 +44,21 @@ function init_data_dir() {
   fi
 }
 
+# Runtime /etc/passwd file permissions safety check to prevent reintroduction
+# of CVE-2020-10695. !!! DO NOT REMOVE !!!
+ETC_PASSWD_PERMS=$(stat -c '%a' "/etc/passwd")
+if [ "${ETC_PASSWD_PERMS}" -gt "644" ]
+then
+  ERROR_MESSAGE=(
+    "Permissions '${ETC_PASSWD_PERMS}' for '/etc/passwd' are too open!"
+    "It is recommended the '/etc/passwd' file can only be modified by"
+    "root or users with sudo privileges and readable by all system users."
+    "Cannot start the '${JBOSS_IMAGE_NAME}', version '${JBOSS_IMAGE_VERSION}'!"
+  )
+  for msg in "${ERROR_MESSAGE[@]}"; do log_error "${msg}"; done
+  exit 1
+fi
+
 if [ "${SPLIT_DATA^^}" = "TRUE" ]; then
   source /opt/partition/partitionPV.sh
 

--- a/modules/sso/config/launch/setup/74/configure.sh
+++ b/modules/sso/config/launch/setup/74/configure.sh
@@ -12,6 +12,14 @@ cp ${ADDED_DIR}/openshift-launch.sh ${ADDED_DIR}/openshift-migrate.sh $JBOSS_HOM
 mkdir -p ${JBOSS_HOME}/bin/launch
 cp -r ${ADDED_DIR}/launch/* ${JBOSS_HOME}/bin/launch
 
+# KEYCLOAK-13585 Since using nss_wrapper, modifications of system's /etc/passwd
+# file when container is run using an arbitrary assigned UID aren't neither
+# needed nor expected anymore. Delete the unused 'passwd.sh' script to quieten
+# a permission denied warning trying to modify /etc/passwd when container is run
+# using an arbitrary assigned UID. But that permission denied is actually
+# expected since the default permissions of /etc/passwd file weren't changed
+rm -rf "${JBOSS_HOME}/bin/launch/passwd.sh"
+
 mkdir ${JBOSS_HOME}/root-app-redirect
 cp ${ADDED_DIR}/index.html ${JBOSS_HOME}/root-app-redirect
 rm -rf ${JBOSS_HOME}/welcome-content

--- a/modules/sso/security/cve-2020-10695/configure.sh
+++ b/modules/sso/security/cve-2020-10695/configure.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -e
+
+# 185 is the registered static UID of the 'jboss' user. See uidgid file from
+# the 'setup' package for details:
+#   $ grep -P '185\s+' $(rpm -ql setup | grep uidgid)
+#
+JBOSS_WILDFLY_USER_STATIC_UID=185
+
+declare -A USER=(
+  # For backward-compatibility default to 185 as the UID of the 'jboss' user.
+  ["UID"]="${JBOSS_WILDFLY_USER_STATIC_UID}"
+  ["GID"]="${JBOSS_WILDFLY_USER_STATIC_UID}"
+  ["NAME"]="jboss"
+  ["GECOS"]="JBoss User"
+  ["HOME"]="/home/jboss"
+  ["SHELL"]="/sbin/nologin"
+)
+
+# Specify the intermediary location of the newly generated passwd file for
+# the NSS API wrapper
+GENERATED_PASSWD="/root/passwd"
+
+# Generate passwd file based on 185 UID
+# First mirror the current content of system's /etc/passwd into the new passwd
+# file (except the possibly already existing entries for the 'jboss' user)
+grep -v                  \
+     -e "^${USER[UID]}"  \
+     -e "^${USER[NAME]}" \
+     "/etc/passwd" > "${GENERATED_PASSWD}"
+
+# Then add entry for the 'jboss' user into the new passwd file for NSS API
+JBOSS_USER_ENTRY=(
+  "${USER[NAME]}:x:${USER[UID]}:${USER[GID]}:"
+  "${USER[GECOS]}:${USER[HOME]}:${USER[SHELL]}"
+)
+printf '%s' "${JBOSS_USER_ENTRY[@]}" $'\n' >> "${GENERATED_PASSWD}"
+
+# Instruct NSS wrapper to use previously created passwd file so the 'jboss'
+# user is known to the system and it's possible to create their home directory
+export LD_PRELOAD="libnss_wrapper.so"
+export NSS_WRAPPER_PASSWD="${GENERATED_PASSWD}"
+export NSS_WRAPPER_GROUP="/etc/group"
+
+# 'jboss' user is known to the system, but their home directory doesn't exist
+# yet. Create it
+if [ ! -d "${USER[HOME]}" ]
+then
+  INFO_MESSAGE=(
+    "Creating home directory for the '${USER[NAME]}' user: '${USER[HOME]}'"
+  )
+  echo -e "${INFO_MESSAGE[@]}"
+  # Exit with error if the home directory failed to be created
+  if ! mkhomedir_helper "${USER[NAME]}"
+  then
+    ERROR_MESSAGE=(
+      "Failed to create the '${USER[HOME]}' home directory for the"
+      "'${USER[NAME]}' user!\nCannot continue, exiting."
+    )
+    echo -e "${ERROR_MESSAGE[@]}"
+    exit 1
+  fi
+fi
+
+# Needed to support image running as an arbitrary user.
+# See 'Support Arbitrary User IDs' section of:
+#   https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
+chmod ug+rwX "${USER[HOME]}"
+
+# Create the default 'jboss' group for the 'jboss' user
+groupadd -r "${USER[NAME]}" -g "${USER[GID]}"
+
+# Move intermediary NSS API passwd file to home directory of the 'jboss' user
+# and set 'jboss' as the owner. This is needed later dynamically to be able
+# adjust the UID of the 'jboss' user in the passwd file to match the effective
+# UID the container is running under
+NEW_DESTINATION="${USER[HOME]}/passwd"
+mv "${GENERATED_PASSWD}" "${NEW_DESTINATION}"
+# Instruct NSS wrapper to start using the passwd file from this new location
+export NSS_WRAPPER_PASSWD="${NEW_DESTINATION}"
+
+# Change ownership of the NSS API passwd file
+chown "${USER[UID]}":"${USER[GID]}" "${NEW_DESTINATION}"
+
+# Set 'jboss' user to be member of the 'jboss' suplementary group
+usermod -aG "${USER[NAME]}" "${USER[NAME]}"

--- a/modules/sso/security/cve-2020-10695/module.yaml
+++ b/modules/sso/security/cve-2020-10695/module.yaml
@@ -1,0 +1,37 @@
+schema_version: 1
+name: sso.security.cve-2020-10695
+version: '1.0'
+description: "Avoid CVE-2020-10695 by generating a new passwd file based on the
+  chosen user ID and instructing the NSS wrapper to use this passwd file rather
+  than to loosen the permissions of the system's /etc/passwd file from its
+  default recommended 644 setting."
+
+envs:
+- name: HOME
+  value: "/home/jboss"
+  # Per https://access.redhat.com/articles/4859371 for Java based processes
+  # specify also 'user.home' property
+- name: MAVEN_OPTS
+  value: "-Duser.home=$HOME"
+  # Propagate the fact about utilizing nss_wrapper to the subsequent modules
+- name: LD_PRELOAD
+  value: "libnss_wrapper.so"
+- name: NSS_WRAPPER_PASSWD
+  value: "/home/jboss/passwd"
+- name: NSS_WRAPPER_GROUP
+  value: "/etc/group"
+
+packages:
+  install:
+  # Dependencies of the original 'jboss.container.user' module
+  - unzip
+  - tar
+  - rsync
+  - shadow-utils
+  # NSS API dependencies
+  - nss_wrapper
+  # Needed for mkhomedir_helper
+  - pam
+
+execute:
+- script: configure.sh

--- a/modules/sso/sso-jdk/11/module.yaml
+++ b/modules/sso/sso-jdk/11/module.yaml
@@ -27,7 +27,8 @@ packages:
 
 modules:
   install:
-  - name: jboss.container.user
+  - name: sso.security.cve-2020-10695
+    version: '1.0'
 
 execute:
 - script: configure.sh

--- a/modules/sso/sso-jdk/8/module.yaml
+++ b/modules/sso/sso-jdk/8/module.yaml
@@ -27,7 +27,8 @@ packages:
 
 modules:
   install:
-  - name: jboss.container.user
+  - name: sso.security.cve-2020-10695
+    version: '1.0'
 
 execute:
 - script: configure.sh


### PR DESCRIPTION
    [KEYCLOAK-13585] Prevent CVE-2020-10695 by using nss_wrapper approach
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

For reference further articles / details about the issue itself & suggested fix(es):

- [OpenShift Containers - Modification of /etc/passwd](https://access.redhat.com/articles/4859371)
- [Example nss_wrapper fix used by Jenkins image](https://github.com/openshift/jenkins/pull/1024/files#)
- [Official OCP v3.X documentation WRT to _nss_wrapper_ use](https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines)
  (scroll down to _nss\_wrapper_ related paragraph below to **Support Arbitrary User IDs** subsection)

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
