### PR TITLE
[KEYCLOAK-16565] Allow users in the root group to access files/dirs created by 'jboss' user

### DIFF
--- a/modules/sso/security/cve-2020-10695/configure.sh
+++ b/modules/sso/security/cve-2020-10695/configure.sh
@@ -10,16 +10,28 @@ JBOSS_WILDFLY_USER_STATIC_UID=185
 declare -A USER=(
   # For backward-compatibility default to 185 as the UID of the 'jboss' user.
   ["UID"]="${JBOSS_WILDFLY_USER_STATIC_UID}"
-  ["GID"]="${JBOSS_WILDFLY_USER_STATIC_UID}"
+  # Allow users of root group to access directories / files created by 'jboss'
+  # user in the built image. See 'Support Arbitrary User IDs' section of:
+  #    https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
+  ["GID"]="0"
   ["NAME"]="jboss"
   ["GECOS"]="JBoss User"
   ["HOME"]="/home/jboss"
   ["SHELL"]="/sbin/nologin"
 )
 
-# Specify the intermediary location of the newly generated passwd file for
-# the NSS API wrapper
-GENERATED_PASSWD="/root/passwd"
+# Specify the location of the newly generated passwd file for NSS API wrapper
+# Create parent directories on that path as necessary
+GENERATED_PASSWD="/etc/rh-sso/passwd"
+if [ ! -d $(dirname "${GENERATED_PASSWD}") ]
+then
+  INFO_MESSAGE=(
+    "Creating directory to hold the NSS API user accounts file:"
+    "'$(dirname ${GENERATED_PASSWD})/'"
+  )
+  echo -e "${INFO_MESSAGE[@]}"
+  mkdir -p $(dirname "${GENERATED_PASSWD}")
+fi
 
 # Generate passwd file based on 185 UID
 # First mirror the current content of system's /etc/passwd into the new passwd
@@ -36,14 +48,13 @@ JBOSS_USER_ENTRY=(
 )
 printf '%s' "${JBOSS_USER_ENTRY[@]}" $'\n' >> "${GENERATED_PASSWD}"
 
-# Instruct NSS wrapper to use previously created passwd file so the 'jboss'
-# user is known to the system and it's possible to create their home directory
+# Instruct NSS wrapper to use previously created passwd file
 export LD_PRELOAD="libnss_wrapper.so"
 export NSS_WRAPPER_PASSWD="${GENERATED_PASSWD}"
 export NSS_WRAPPER_GROUP="/etc/group"
 
-# 'jboss' user is known to the system, but their home directory doesn't exist
-# yet. Create it
+# The 'jboss' user is known to the system via the NSS API passwd file,
+# but their home directory doesn't exist yet. Create it
 if [ ! -d "${USER[HOME]}" ]
 then
   INFO_MESSAGE=(
@@ -68,19 +79,7 @@ fi
 chmod ug+rwX "${USER[HOME]}"
 
 # Create the default 'jboss' group for the 'jboss' user
-groupadd -r "${USER[NAME]}" -g "${USER[GID]}"
-
-# Move intermediary NSS API passwd file to home directory of the 'jboss' user
-# and set 'jboss' as the owner. This is needed later dynamically to be able
-# adjust the UID of the 'jboss' user in the passwd file to match the effective
-# UID the container is running under
-NEW_DESTINATION="${USER[HOME]}/passwd"
-mv "${GENERATED_PASSWD}" "${NEW_DESTINATION}"
-# Instruct NSS wrapper to start using the passwd file from this new location
-export NSS_WRAPPER_PASSWD="${NEW_DESTINATION}"
-
-# Change ownership of the NSS API passwd file
-chown "${USER[UID]}":"${USER[GID]}" "${NEW_DESTINATION}"
+groupadd -r "${USER[NAME]}" -g "${USER[UID]}"
 
 # Set 'jboss' user to be member of the 'jboss' suplementary group
 usermod -aG "${USER[NAME]}" "${USER[NAME]}"

--- a/modules/sso/security/cve-2020-10695/module.yaml
+++ b/modules/sso/security/cve-2020-10695/module.yaml
@@ -17,7 +17,7 @@ envs:
 - name: LD_PRELOAD
   value: "libnss_wrapper.so"
 - name: NSS_WRAPPER_PASSWD
-  value: "/home/jboss/passwd"
+  value: "/etc/rh-sso/passwd"
 - name: NSS_WRAPPER_GROUP
   value: "/etc/group"
 


### PR DESCRIPTION
    [KEYCLOAK-16565] Allow users in the root group (e.g. the users the
    container is running under on OpenShift) to access directories/files
    created by the 'jboss' user in the built image. See
    'Support Arbitrary User IDs' section of:
    
        https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
    
    Simultaneously with this, move the passwd file generated for NSS API
    outside of home 'jboss' directory, so it's only writable by 'jboss'
    or root user in the built image.
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
