### PR TITLE
[KEYCLOAK-16736] Return the 'WORKDIR' instruction to the 'CMD' instruction in the Dockerfile used to build the RH-SSO image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -110,6 +110,9 @@ modules:
           - name: openshift-layer
           - name: keycloak-layer
 
+          # Various SSO image pre-launch checks to prevent regressions
+          - name: sso-pre-launch-checks
+
           # This needs to be the very last, after all updates to standalone-openshift.xml have been done. See eg. https://access.redhat.com/solutions/3402171 for use
           - name: os-eap-extensions
           - name: sso-cli-extensions
@@ -131,6 +134,7 @@ artifacts:
        md5: 921892c5a2234ca2bd09d5fd5ad1aad8
        url: http://$DOWNLOAD_SERVER/devel/candidates/jboss/eap/JBEAP-7.3.5.GA-CR1/jboss-eap-7.3.5.GA-CR1-patch.zip
 run:
-      user: 185
       cmd:
           - "/opt/eap/bin/openshift-launch.sh"
+      user: 185
+      workdir: "/home/jboss"

--- a/modules/sso/config/launch/setup/74/added/launch/openshift-common.sh
+++ b/modules/sso/config/launch/setup/74/added/launch/openshift-common.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Openshift EAP launch script
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
@@ -6,8 +6,8 @@ if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
 fi
 
-CONFIG_FILE=$JBOSS_HOME/standalone/configuration/standalone-openshift.xml
-LOGGING_FILE=$JBOSS_HOME/standalone/configuration/logging.properties
+export CONFIG_FILE="${JBOSS_HOME}/standalone/configuration/standalone-openshift.xml"
+export LOGGING_FILE="${JBOSS_HOME}/standalone/configuration/logging.properties"
 
 #For backward compatibility
 ADMIN_USERNAME=${ADMIN_USERNAME:-${EAP_ADMIN_USERNAME:-$DEFAULT_ADMIN_USERNAME}}
@@ -22,26 +22,27 @@ SECDOMAIN_ROLES_PROPERTIES=${SECDOMAIN_ROLES_PROPERTIES:-${EAP_SECDOMAIN_ROLES_P
 SECDOMAIN_NAME=${SECDOMAIN_NAME:-$EAP_SECDOMAIN_NAME}
 SECDOMAIN_PASSWORD_STACKING=${SECDOMAIN_PASSWORD_STACKING:-$EAP_SECDOMAIN_PASSWORD_STACKING}
 
-IMPORT_REALM_FILE=$JBOSS_HOME/standalone/configuration/import-realm.json
+export IMPORT_REALM_FILE="${JBOSS_HOME}/standalone/configuration/import-realm.json"
 
-CONFIGURE_SCRIPTS=(
-  $JBOSS_HOME/bin/launch/configure_extensions.sh
-  $JBOSS_HOME/bin/launch/datasource.sh
-  $JBOSS_HOME/bin/launch/resource-adapter.sh
-  $JBOSS_HOME/bin/launch/admin.sh
-  $JBOSS_HOME/bin/launch/ha.sh
-  $JBOSS_HOME/bin/launch/openshift-x509.sh
-  $JBOSS_HOME/bin/launch/jgroups.sh
-  $JBOSS_HOME/bin/launch/https.sh
-  $JBOSS_HOME/bin/launch/json_logging.sh
-  $JBOSS_HOME/bin/launch/security-domains.sh
-  $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
-  $JBOSS_HOME/bin/launch/deploymentScanner.sh
-  $JBOSS_HOME/bin/launch/ports.sh
-  $JBOSS_HOME/bin/launch/add-sso-admin-user.sh
-  $JBOSS_HOME/bin/launch/add-sso-realm.sh
-  $JBOSS_HOME/bin/launch/keycloak-spi.sh
-  $JBOSS_HOME/bin/launch/access_log_valve.sh
-  $JBOSS_HOME/bin/launch/configure_sso_cli_extensions.sh
+export CONFIGURE_SCRIPTS=(
+  "${JBOSS_HOME}/bin/launch/configure_extensions.sh"
+  "${JBOSS_HOME}/bin/launch/datasource.sh"
+  "${JBOSS_HOME}/bin/launch/resource-adapter.sh"
+  "${JBOSS_HOME}/bin/launch/admin.sh"
+  "${JBOSS_HOME}/bin/launch/ha.sh"
+  "${JBOSS_HOME}/bin/launch/openshift-x509.sh"
+  "${JBOSS_HOME}/bin/launch/jgroups.sh"
+  "${JBOSS_HOME}/bin/launch/https.sh"
+  "${JBOSS_HOME}/bin/launch/json_logging.sh"
+  "${JBOSS_HOME}/bin/launch/security-domains.sh"
+  "${JBOSS_HOME}/bin/launch/jboss_modules_system_pkgs.sh"
+  "${JBOSS_HOME}/bin/launch/deploymentScanner.sh"
+  "${JBOSS_HOME}/bin/launch/ports.sh"
+  "${JBOSS_HOME}/bin/launch/add-sso-admin-user.sh"
+  "${JBOSS_HOME}/bin/launch/add-sso-realm.sh"
+  "${JBOSS_HOME}/bin/launch/keycloak-spi.sh"
+  "${JBOSS_HOME}/bin/launch/access_log_valve.sh"
+  "${JBOSS_HOME}/bin/launch/configure_sso_cli_extensions.sh"
+  "${JBOSS_HOME}/bin/launch/sso_image_pre_launch_checks.sh"
   /opt/run-java/proxy-options
 )

--- a/modules/sso/config/launch/setup/74/added/openshift-launch.sh
+++ b/modules/sso/config/launch/setup/74/added/openshift-launch.sh
@@ -51,21 +51,6 @@ function init_data_dir() {
   fi
 }
 
-# Runtime /etc/passwd file permissions safety check to prevent reintroduction
-# of CVE-2020-10695. !!! DO NOT REMOVE !!!
-ETC_PASSWD_PERMS=$(stat -c '%a' "/etc/passwd")
-if [ "${ETC_PASSWD_PERMS}" -gt "644" ]
-then
-  ERROR_MESSAGE=(
-    "Permissions '${ETC_PASSWD_PERMS}' for '/etc/passwd' are too open!"
-    "It is recommended the '/etc/passwd' file can only be modified by"
-    "root or users with sudo privileges and readable by all system users."
-    "Cannot start the '${JBOSS_IMAGE_NAME}', version '${JBOSS_IMAGE_VERSION}'!"
-  )
-  for msg in "${ERROR_MESSAGE[@]}"; do log_error "${msg}"; done
-  exit 1
-fi
-
 if [ "${SPLIT_DATA^^}" = "TRUE" ]; then
   source /opt/partition/partitionPV.sh
 

--- a/modules/sso/config/launch/setup/74/configure.sh
+++ b/modules/sso/config/launch/setup/74/configure.sh
@@ -2,15 +2,18 @@
 
 set -e
 
-SCRIPT_DIR=$(dirname $0)
+SCRIPT_DIR=$(dirname "$0")
 ADDED_DIR=${SCRIPT_DIR}/added
 
-cp ${ADDED_DIR}/standalone-openshift.xml $JBOSS_HOME/standalone/configuration
-cp ${ADDED_DIR}/import-realm.json $JBOSS_HOME/standalone/configuration
-cp ${ADDED_DIR}/openshift-launch.sh ${ADDED_DIR}/openshift-migrate.sh $JBOSS_HOME/bin/
+cp "${ADDED_DIR}/standalone-openshift.xml" "${JBOSS_HOME}/standalone/configuration"
+cp "${ADDED_DIR}/import-realm.json" "${JBOSS_HOME}/standalone/configuration"
+cp "${ADDED_DIR}/openshift-launch.sh" "${ADDED_DIR}/openshift-migrate.sh" "${JBOSS_HOME}/bin/"
 
-mkdir -p ${JBOSS_HOME}/bin/launch
-cp -r ${ADDED_DIR}/launch/* ${JBOSS_HOME}/bin/launch
+mkdir -p "${JBOSS_HOME}/bin/launch"
+# Intentionally keep the asterisk (*) character in the next statement outside
+# of the double quotes to achieve proper globbing / expansion to all applicable
+# scripts
+cp -r "${ADDED_DIR}"/launch/* "${JBOSS_HOME}/bin/launch"
 
 # KEYCLOAK-13585 Since using nss_wrapper, modifications of system's /etc/passwd
 # file when container is run using an arbitrary assigned UID aren't neither
@@ -20,9 +23,9 @@ cp -r ${ADDED_DIR}/launch/* ${JBOSS_HOME}/bin/launch
 # expected since the default permissions of /etc/passwd file weren't changed
 rm -rf "${JBOSS_HOME}/bin/launch/passwd.sh"
 
-mkdir ${JBOSS_HOME}/root-app-redirect
-cp ${ADDED_DIR}/index.html ${JBOSS_HOME}/root-app-redirect
-rm -rf ${JBOSS_HOME}/welcome-content
+mkdir "${JBOSS_HOME}/root-app-redirect"
+cp "${ADDED_DIR}/index.html" "${JBOSS_HOME}/root-app-redirect"
+rm -rf "${JBOSS_HOME}/welcome-content"
 
-chown -R jboss:root $JBOSS_HOME
-chmod -R g+rwX $JBOSS_HOME
+chown -R jboss:root "${JBOSS_HOME}"
+chmod -R g+rwX "${JBOSS_HOME}"

--- a/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
+++ b/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Include logging module
+# shellcheck source=/dev/null
+source "${JBOSS_HOME}/bin/launch/logging.sh"
+
+function postConfigure() {
+  verify_CVE_2020_10695_fix_present
+  verify_KEYCLOAK_16736_fix_present
+}
+
+# KEYCLOAK-13585 / RH BZ#1817530 / CVE-2020-10695:
+#
+# Runtime /etc/passwd file permissions safety check to prevent
+# reintroduction of CVE-2020-10695. !!! DO NOT REMOVE !!!
+#
+function verify_CVE_2020_10695_fix_present() {
+  local etcPasswdPerms
+  etcPasswdPerms=$(stat -c '%a' "/etc/passwd")
+  local -r errorExitCode="1"
+  if [ "${etcPasswdPerms}" -gt "644" ]
+  then
+    log_error "Permissions '${etcPasswdPerms}' for '/etc/passwd' are too open!"
+    log_error "It is recommended the '/etc/passwd' file can only be modified by"
+    log_error "root or users with sudo privileges and readable by all system users."
+    log_error "Cannot start the '${JBOSS_IMAGE_NAME}', version '${JBOSS_IMAGE_VERSION}'!"
+    exit "${errorExitCode}"
+  fi
+}
+
+# KEYCLOAK-16736:
+#
+# Verify 'CMD' instruction in the Dockerfile used to build
+# the image contains an associated 'WORKDIR' instruction
+#
+function verify_KEYCLOAK_16736_fix_present() {
+  # Intentionally expand to any Dockerfile matching the image name and version,
+  # regardless of the particular image release
+  # shellcheck disable=SC2061
+  # shellcheck disable=SC2086
+  local -r ssoImageDockerfile=$(find /root/buildinfo -maxdepth 1 -type f -name Dockerfile-${JBOSS_IMAGE_NAME/\//-}-${JBOSS_IMAGE_VERSION}-*)
+  local -r errorExitCode="1"
+  # Throw an error if the image doesn't contain a Dockerfile we could check
+  if [ "x${ssoImageDockerfile}x" == "xx" ]
+  then
+    log_error "The specified Dockerfile: '${ssoImageDockerfile}' does not exist!"
+    exit "${errorExitCode}"
+  # Confirm 'WORKDIR' instruction is defined in that Dockerfile
+  elif ! grep -q 'WORKDIR' "${ssoImageDockerfile}"
+  then
+    log_error "'WORKDIR' instruction is not defined in the ${ssoImageDockerfile} Dockerfile!"
+    exit "${errorExitCode}"
+  # And its value is identical to the value of $HOME variable
+  elif ! grep -q "WORKDIR ${HOME}" "${ssoImageDockerfile}"
+  then
+    log_error "The value of 'WORKDIR' instruction in the ${ssoImageDockerfile}"
+    log_error "doesn't match value of '${HOME}' variable!"
+    exit "${errorExitCode}"
+  fi
+}

--- a/modules/sso/sso-pre-launch-checks/configure.sh
+++ b/modules/sso/sso-pre-launch-checks/configure.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(dirname "$0")
+ADDED_DIR=${SCRIPT_DIR}/added
+
+cp "${ADDED_DIR}/sso_image_pre_launch_checks.sh" "${JBOSS_HOME}/bin/launch"

--- a/modules/sso/sso-pre-launch-checks/module.yaml
+++ b/modules/sso/sso-pre-launch-checks/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: sso-pre-launch-checks
+version: '1.0'
+description: Module to perform various RH-SSO image pre-launch checks to prevent regressions. Intended to contain pretty limited set of bootstrap tests to achieve certain aspects of the image meet security standards and provide functionality relied upon by 3rd party projects.
+execute:
+- script: configure.sh
+  user: '185'


### PR DESCRIPTION

    [KEYCLOAK-16736] Return the 'WORKDIR' instruction to the 'CMD'
    instruction in the Dockerfile used to build the RH-SSO image
    
    Also add a test via new 'sso-pre-launch-checks' module to prevent
    this type of regression in the future. Move the existing CVE-2020-10695
    check to 'sso-pre-launch-checks' module too
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
