### PR TITLE
Fix eap 7.3.0 and 7.3.7 module artifacts data

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -124,15 +124,15 @@ packages:
       content_sets_file: content_sets.yaml
 
 artifacts:
-     - name: jboss-eap-7.3.0.zip
+     - name: jboss-eap-7.3.zip
        target: jboss-eap-7.3.zip
        md5: 3dba80cc1be17b00cb901441111886f3
        url: http://$DOWNLOAD_SERVER/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip
 
-     - name: jboss-eap-7.3.7.GA-CR1-patch
-       target: jboss-eap-7.3.7.GA-CR1-patch.zip
+     - name: jboss-eap-7.3.7-patch
+       target: jboss-eap-7.3.7-patch.zip
        md5: 885e21cc728d1d8d1d4cb9fd793b5e10
-       url: http://$DOWNLOAD_SERVER/devel/candidates/JBEAP/JBEAP-7.3.7-GA-CR1/jboss-eap-7.3.7.GA-CR1-patch.zip
+       url: http://$DOWNLOAD_SERVER/devel/candidates/JBEAP/JBEAP-7.3.7.GA-CR1/jboss-eap-7.3.7.GA-CR1-patch.zip
 
 run:
       cmd:


### PR DESCRIPTION
@iankko @pskopek 
This PR is necessary because EAP has lately started enforcing it's modules names: https://github.com/jboss-container-images/jboss-eap-7-image/blob/51f9652f91bdbbfb38e9cb91c79c3337361d946e/modules/eap-737/module.yaml#L6-L13