### PR TITLE
[KEYCLOAK-18004] Ensure "find" executable is available (findutils rpm is installed) in the image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -122,6 +122,11 @@ modules:
 packages:
       manager: microdnf
       content_sets_file: content_sets.yaml
+      install:
+      # "find" executable is required by various CCT & SSO modules
+      - findutils
+      # "which" tool is handy for debugging issues / troubleshooting
+      - which
 
 artifacts:
      - name: jboss-eap-7.3.zip


### PR DESCRIPTION
    [KEYCLOAK-18004] Add the "find" executable (findutils rpm) back since
    various CCT & SSO modules expect it to be available
    
    Also add the "which" tool (which rpm) which is useful for debugging
    issues with the image (troubleshooting)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Examples of CCT modules (not a complete list), which are utilizing (depending on) the `find` executable to be available:

- `jboss.container.s2i.core.api`,
- `jboss.container.maven.default.bash`,
- `openshift-layer`
- ...

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
