### PR TITLE
[KEYCLOAK-18896] Reference only groupified OpenShift API resources across RH-SSO templates, doc & test files

### DIFF
--- a/template.adoc.in
+++ b/template.adoc.in
@@ -215,7 +215,7 @@ For DNS_PING to work, the following steps must be taken:
 [source,yaml]
 ----
 kind: Service
-apiVersion: v1
+apiVersion: core/v1
 spec:
     clusterIP: None
     ports:

--- a/templates/openj9/sso74-openj9-https.json
+++ b/templates/openj9/sso74-openj9-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -214,7 +214,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -238,7 +238,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -262,7 +262,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -288,7 +288,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -308,7 +308,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -331,7 +331,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/openj9/sso74-openj9-image-stream.json
+++ b/templates/openj9/sso74-openj9-image-stream.json
@@ -1,58 +1,45 @@
 {
-    "kind": "List",
-    "apiVersion": "v1",
+    "kind": "ImageStream",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
-        "name": "sso74-openj9-image-stream",
+        "name": "sso74-openj9-openshift-rhel8",
         "annotations": {
-            "description": "ImageStream definition for Red Hat Single Sign-On 7.4 on OpenJ9.",
-            "openshift.io/provider-display-name": "Red Hat, Inc."
+            "description": "Red Hat Single Sign-On 7.4 on OpenJ9",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "version": "7.4.8.GA"
         }
     },
-    "items": [
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "sso74-openj9-openshift-rhel8",
-                "annotations": {
-                    "description": "Red Hat Single Sign-On 7.4 on OpenJ9",
-                    "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.8.GA"
+    "labels": {
+        "rhsso": "7.4.8.GA"
+    },
+    "spec": {
+        "tags": [
+            {
+                "name": "latest",
+                "from": {
+                    "kind": "ImageStreamTag",
+                    "name": "7.4"
                 }
             },
-            "labels": {
-                "rhsso": "7.4.8.GA"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "latest",
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "7.4"
-                        }
-                    },
-                    {
-                        "name": "7.4",
-                        "annotations": {
-                            "description": "Red Hat Single Sign-On 7.4 on OpenJ9 image",
-                            "iconClass": "icon-sso",
-                            "tags": "sso,keycloak,redhat,hidden",
-                            "supports": "sso:7.4",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4"
-                        }
-                    }
-                ]
+            {
+                "name": "7.4",
+                "annotations": {
+                    "description": "Red Hat Single Sign-On 7.4 on OpenJ9 image",
+                    "iconClass": "icon-sso",
+                    "tags": "sso,keycloak,redhat,hidden",
+                    "supports": "sso:7.4",
+                    "version": "1.0",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9"
+                },
+                "referencePolicy": {
+                    "type": "Local"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4"
+                }
             }
-        }
-    ]
+        ]
+    }
 }

--- a/templates/openj9/sso74-openj9-ocp4-x509-https.json
+++ b/templates/openj9/sso74-openj9-ocp4-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -115,8 +115,8 @@
     ],
     "objects": [
         {
-            "apiVersion": "v1",
             "kind": "ConfigMap",
+            "apiVersion": "core/v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -130,7 +130,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -155,7 +155,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -182,7 +182,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -204,7 +204,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/openj9/sso74-openj9-ocp4-x509-postgresql-persistent.json
+++ b/templates/openj9/sso74-openj9-ocp4-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -171,7 +171,7 @@
     ],
     "objects": [
         {
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "kind": "ConfigMap",
             "metadata": {
                 "annotations": {
@@ -186,7 +186,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -212,7 +212,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -236,7 +236,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -263,7 +263,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -285,7 +285,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -507,7 +507,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -627,8 +627,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "core/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/openj9/sso74-openj9-postgresql-persistent.json
+++ b/templates/openj9/sso74-openj9-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -270,7 +270,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -295,7 +295,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -320,7 +320,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -344,7 +344,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -370,7 +370,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -390,7 +390,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -413,7 +413,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -803,8 +803,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "core/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/openj9/sso74-openj9-postgresql.json
+++ b/templates/openj9/sso74-openj9-postgresql.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -263,7 +263,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -289,7 +289,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -315,7 +315,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -340,7 +340,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -366,7 +366,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -387,7 +387,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -411,7 +411,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {

--- a/templates/openj9/sso74-openj9-x509-https.json
+++ b/templates/openj9/sso74-openj9-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -116,7 +116,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -141,7 +141,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -168,7 +168,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -190,7 +190,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/openj9/sso74-openj9-x509-postgresql-persistent.json
+++ b/templates/openj9/sso74-openj9-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -172,7 +172,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -198,7 +198,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -222,7 +222,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -249,7 +249,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -271,7 +271,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -482,7 +482,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -602,8 +602,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "core/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso74-https.json
+++ b/templates/sso74-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -214,7 +214,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -238,7 +238,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -262,7 +262,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -288,7 +288,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -308,7 +308,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -331,7 +331,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/sso74-image-stream.json
+++ b/templates/sso74-image-stream.json
@@ -1,58 +1,45 @@
 {
-    "kind": "List",
-    "apiVersion": "v1",
+    "kind": "ImageStream",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
-        "name": "sso74-image-stream",
+        "name": "sso74-openshift-rhel8",
         "annotations": {
-            "description": "ImageStream definition for Red Hat Single Sign-On 7.4 on OpenJDK.",
-            "openshift.io/provider-display-name": "Red Hat, Inc."
+            "description": "Red Hat Single Sign-On 7.4 on OpenJDK",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "version": "7.4.8.GA"
         }
     },
-    "items": [
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "sso74-openshift-rhel8",
-                "annotations": {
-                    "description": "Red Hat Single Sign-On 7.4 on OpenJDK",
-                    "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.8.GA"
+    "labels": {
+        "rhsso": "7.4.8.GA"
+    },
+    "spec": {
+        "tags": [
+            {
+                "name": "latest",
+                "from": {
+                    "kind": "ImageStreamTag",
+                    "name": "7.4"
                 }
             },
-            "labels": {
-                "rhsso": "7.4.8.GA"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "latest",
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "7.4"
-                        }
-                    },
-                    {
-                        "name": "7.4",
-                        "annotations": {
-                            "description": "Red Hat Single Sign-On 7.4 on OpenJDK image",
-                            "iconClass": "icon-sso",
-                            "tags": "sso,keycloak,redhat,hidden",
-                            "supports": "sso:7.4",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4"
-                        }
-                    }
-                ]
+            {
+                "name": "7.4",
+                "annotations": {
+                    "description": "Red Hat Single Sign-On 7.4 on OpenJDK image",
+                    "iconClass": "icon-sso",
+                    "tags": "sso,keycloak,redhat,hidden",
+                    "supports": "sso:7.4",
+                    "version": "1.0",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK"
+                },
+                "referencePolicy": {
+                    "type": "Local"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4"
+                }
             }
-        }
-    ]
+        ]
+    }
 }

--- a/templates/sso74-ocp4-x509-https.json
+++ b/templates/sso74-ocp4-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -115,8 +115,8 @@
     ],
     "objects": [
         {
-            "apiVersion": "v1",
             "kind": "ConfigMap",
+            "apiVersion": "core/v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -130,7 +130,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -155,7 +155,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -182,7 +182,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -204,7 +204,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/sso74-ocp4-x509-postgresql-persistent.json
+++ b/templates/sso74-ocp4-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -171,8 +171,8 @@
     ],
     "objects": [
         {
-            "apiVersion": "v1",
             "kind": "ConfigMap",
+            "apiVersion": "core/v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -186,7 +186,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -212,7 +212,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -236,7 +236,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -263,7 +263,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -285,7 +285,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -507,7 +507,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -627,8 +627,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "core/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso74-postgresql-persistent.json
+++ b/templates/sso74-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -270,7 +270,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -295,7 +295,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -320,7 +320,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -344,7 +344,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -370,7 +370,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -390,7 +390,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -413,7 +413,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -803,8 +803,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "core/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso74-postgresql.json
+++ b/templates/sso74-postgresql.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -263,7 +263,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -289,7 +289,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -315,7 +315,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -340,7 +340,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -366,7 +366,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -387,7 +387,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -411,7 +411,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {

--- a/templates/sso74-x509-https.json
+++ b/templates/sso74-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -116,7 +116,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -141,7 +141,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -168,7 +168,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -190,7 +190,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/sso74-x509-postgresql-persistent.json
+++ b/templates/sso74-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -172,7 +172,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -198,7 +198,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "ports": [
                     {
@@ -222,7 +222,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "v1",
+            "apiVersion": "core/v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -249,7 +249,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -271,7 +271,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -482,7 +482,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -602,8 +602,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "core/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/tests/arq/src/test/java/org/jboss/test/arquillian/ce/sso/SsoVaultTest.java
+++ b/tests/arq/src/test/java/org/jboss/test/arquillian/ce/sso/SsoVaultTest.java
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.not;
         })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/sso-app-secret.json")
 @OpenShiftResource("{\n" +
-        "  \"apiVersion\": \"v1\",\n" +
+        "  \"apiVersion\": \"core/v1\",\n" +
         "  \"data\": {\n" +
         "    \"master_smtp__password\": \"bXlTTVRQUHNzd2Q=\"\n" +
         "  },\n" +

--- a/tests/arq/src/test/resources/testrunner-pod.json
+++ b/tests/arq/src/test/resources/testrunner-pod.json
@@ -1,26 +1,26 @@
 {
-	"apiVersion":"v1",
-	"kind": "Pod",
-	"metadata": {
-		"name": "testrunner",
-		"labels": {
-			"name": "testrunner"
-		}
-	},
-	"spec": {
-	    "terminationGracePeriodSeconds": 0,
-		"containers": [{
-			"name": "testrunner",
-			"readinessProbe" : {
-				"exec": {
-					"command": [
-					    "/bin/bash",
-					    "-c",
-					    "/opt/eap/bin/readinessProbe.sh"
-					]
-				}
-			},
-			"image": "jboss-eap-6/eap64-openshift:1.5",
+    "kind": "Pod",
+    "apiVersion":"core/v1",
+    "metadata": {
+        "name": "testrunner",
+        "labels": {
+            "name": "testrunner"
+        }
+    },
+    "spec": {
+        "terminationGracePeriodSeconds": 0,
+        "containers": [{
+            "name": "testrunner",
+            "readinessProbe" : {
+                "exec": {
+                    "command": [
+                        "/bin/bash",
+                        "-c",
+                        "/opt/eap/bin/readinessProbe.sh"
+                    ]
+                }
+            },
+            "image": "jboss-eap-6/eap64-openshift:1.5",
             "ports": [
                 {
                     "containerPort": 8080,
@@ -65,14 +65,14 @@
                     "value": ""
                 },
                 {
-                	"name": "ADMIN_USERNAME",
-                	"value": "admin"
+                    "name": "ADMIN_USERNAME",
+                    "value": "admin"
                 },
                 {
-                	"name": "ADMIN_PASSWORD",
-                	"value": "Admin#70365"
+                    "name": "ADMIN_PASSWORD",
+                    "value": "Admin#70365"
                 }
             ]
-		}]
-	}
+        }]
+    }
 }


### PR DESCRIPTION
    [KEYCLOAK-18896] Change non-groupified OpenShift API resources, referenced
    across various RH-SSO templates, test, and documentation files to their
    OpenShift API groupified counterparts
    
    Refer to particular entry of OCP v4.7 release notes:
    * https://docs.openshift.com/container-platform/4.7/release_notes/ocp-4-7-release-notes.html#ocp-4-7-apiversion-v1
    
    for additional details, background & motivation behind this change
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Note: Consult API Index page for:

- [OCP v3.11](https://docs.openshift.com/container-platform/3.11/rest_api/index.html#index) and for
- [OCP v4.7](https://docs.openshift.com/container-platform/4.7/rest_api/index.html#index)

respectively, for additional details / information on how to specific OpenShift API objects should be mapped to the particular group

**JFTR:** The `List` object / resource definition was removed from both of the affected image streams **intentionally** / **by purpose**, since:

1. There doesn't exist corresponding OpenShift API group object / entry, it could be mapped against,
2. The image stream definition is valid (even) without it (TBH not 100% sure about the motivation, why it got added at the very beginning in the 1-th place)

**Note #2:** JFTR, once this is reviewed / approved, it needs to be cherrypicked into the `sso74-cpaas-dev` branch too (so the templates changes are reflected, when building the image using CPaaS method / approach too)

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
