### PR TITLE
[RH-SSO 7.5.X] [KEYCLOAK-19272] Reference only groupified OpenShift API resources across RH-SSO templates, doc & test files

### DIFF
--- a/templates/openj9/sso75-openj9-https.json
+++ b/templates/openj9/sso75-openj9-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -288,7 +288,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -308,7 +308,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -331,7 +331,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/openj9/sso75-openj9-image-stream.json
+++ b/templates/openj9/sso75-openj9-image-stream.json
@@ -1,58 +1,45 @@
 {
-    "kind": "List",
-    "apiVersion": "v1",
+    "kind": "ImageStream",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
-        "name": "sso75-openj9-image-stream",
+        "name": "sso75-openj9-openshift-rhel8",
         "annotations": {
-            "description": "ImageStream definition for Red Hat Single Sign-On 7.5 on OpenJ9.",
-            "openshift.io/provider-display-name": "Red Hat, Inc."
+            "description": "Red Hat Single Sign-On 7.5 on OpenJ9",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJ9",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "version": "7.5.0.GA"
         }
     },
-    "items": [
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "sso75-openj9-openshift-rhel8",
-                "annotations": {
-                    "description": "Red Hat Single Sign-On 7.5 on OpenJ9",
-                    "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJ9",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.5.0.GA"
+    "labels": {
+        "rhsso": "7.5.0.GA"
+    },
+    "spec": {
+        "tags": [
+            {
+                "name": "latest",
+                "from": {
+                    "kind": "ImageStreamTag",
+                    "name": "7.5"
                 }
             },
-            "labels": {
-                "rhsso": "7.5.0.GA"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "latest",
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "7.5"
-                        }
-                    },
-                    {
-                        "name": "7.5",
-                        "annotations": {
-                            "description": "Red Hat Single Sign-On 7.5 on OpenJ9 image",
-                            "iconClass": "icon-sso",
-                            "tags": "sso,keycloak,redhat,hidden",
-                            "supports": "sso:7.5",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJ9"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/rh-sso-7/sso75-openj9-openshift-rhel8:7.5"
-                        }
-                    }
-                ]
+            {
+                "name": "7.5",
+                "annotations": {
+                    "description": "Red Hat Single Sign-On 7.5 on OpenJ9 image",
+                    "iconClass": "icon-sso",
+                    "tags": "sso,keycloak,redhat,hidden",
+                    "supports": "sso:7.5",
+                    "version": "1.0",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJ9"
+                },
+                "referencePolicy": {
+                    "type": "Local"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/rh-sso-7/sso75-openj9-openshift-rhel8:7.5"
+                }
             }
-        }
-    ]
+        ]
+    }
 }

--- a/templates/openj9/sso75-openj9-ocp4-x509-https.json
+++ b/templates/openj9/sso75-openj9-ocp4-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -115,8 +115,8 @@
     ],
     "objects": [
         {
-            "apiVersion": "v1",
             "kind": "ConfigMap",
+            "apiVersion": "v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -182,7 +182,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -204,7 +204,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/openj9/sso75-openj9-ocp4-x509-postgresql-persistent.json
+++ b/templates/openj9/sso75-openj9-ocp4-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -263,7 +263,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -285,7 +285,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -507,7 +507,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -627,8 +627,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/openj9/sso75-openj9-postgresql-persistent.json
+++ b/templates/openj9/sso75-openj9-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -370,7 +370,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -390,7 +390,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -413,7 +413,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -803,8 +803,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/openj9/sso75-openj9-postgresql.json
+++ b/templates/openj9/sso75-openj9-postgresql.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -366,7 +366,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -387,7 +387,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -411,7 +411,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {

--- a/templates/openj9/sso75-openj9-x509-https.json
+++ b/templates/openj9/sso75-openj9-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -168,7 +168,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -190,7 +190,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/openj9/sso75-openj9-x509-postgresql-persistent.json
+++ b/templates/openj9/sso75-openj9-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -249,7 +249,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -271,7 +271,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -482,7 +482,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -602,8 +602,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso75-https.json
+++ b/templates/sso75-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -288,7 +288,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -308,7 +308,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -331,7 +331,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/sso75-image-stream.json
+++ b/templates/sso75-image-stream.json
@@ -1,58 +1,45 @@
 {
-    "kind": "List",
-    "apiVersion": "v1",
+    "kind": "ImageStream",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
-        "name": "sso75-image-stream",
+        "name": "sso75-openshift-rhel8",
         "annotations": {
-            "description": "ImageStream definition for Red Hat Single Sign-On 7.5 on OpenJDK.",
-            "openshift.io/provider-display-name": "Red Hat, Inc."
+            "description": "Red Hat Single Sign-On 7.5 on OpenJDK",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "version": "7.5.0.GA"
         }
     },
-    "items": [
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "sso75-openshift-rhel8",
-                "annotations": {
-                    "description": "Red Hat Single Sign-On 7.5 on OpenJDK",
-                    "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.5.0.GA"
+    "labels": {
+        "rhsso": "7.5.0.GA"
+    },
+    "spec": {
+        "tags": [
+            {
+                "name": "latest",
+                "from": {
+                    "kind": "ImageStreamTag",
+                    "name": "7.5"
                 }
             },
-            "labels": {
-                "rhsso": "7.5.0.GA"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "latest",
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "7.5"
-                        }
-                    },
-                    {
-                        "name": "7.5",
-                        "annotations": {
-                            "description": "Red Hat Single Sign-On 7.5 on OpenJDK image",
-                            "iconClass": "icon-sso",
-                            "tags": "sso,keycloak,redhat,hidden",
-                            "supports": "sso:7.5",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5"
-                        }
-                    }
-                ]
+            {
+                "name": "7.5",
+                "annotations": {
+                    "description": "Red Hat Single Sign-On 7.5 on OpenJDK image",
+                    "iconClass": "icon-sso",
+                    "tags": "sso,keycloak,redhat,hidden",
+                    "supports": "sso:7.5",
+                    "version": "1.0",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK"
+                },
+                "referencePolicy": {
+                    "type": "Local"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5"
+                }
             }
-        }
-    ]
+        ]
+    }
 }

--- a/templates/sso75-ocp4-x509-https.json
+++ b/templates/sso75-ocp4-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -115,8 +115,8 @@
     ],
     "objects": [
         {
-            "apiVersion": "v1",
             "kind": "ConfigMap",
+            "apiVersion": "v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -182,7 +182,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -204,7 +204,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/sso75-ocp4-x509-postgresql-persistent.json
+++ b/templates/sso75-ocp4-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -171,8 +171,8 @@
     ],
     "objects": [
         {
-            "apiVersion": "v1",
             "kind": "ConfigMap",
+            "apiVersion": "v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -263,7 +263,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -285,7 +285,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -507,7 +507,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -627,8 +627,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso75-postgresql-persistent.json
+++ b/templates/sso75-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -370,7 +370,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -390,7 +390,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -413,7 +413,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -803,8 +803,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso75-postgresql.json
+++ b/templates/sso75-postgresql.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -366,7 +366,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -387,7 +387,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -411,7 +411,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -683,7 +683,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {

--- a/templates/sso75-x509-https.json
+++ b/templates/sso75-x509-https.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -168,7 +168,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -190,7 +190,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/sso75-x509-postgresql-persistent.json
+++ b/templates/sso75-x509-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass" : "icon-sso",
@@ -249,7 +249,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -271,7 +271,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -482,7 +482,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql",
                 "labels": {
@@ -602,8 +602,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/tests/arq/src/test/resources/testrunner-pod.json
+++ b/tests/arq/src/test/resources/testrunner-pod.json
@@ -1,26 +1,26 @@
 {
-	"apiVersion":"v1",
-	"kind": "Pod",
-	"metadata": {
-		"name": "testrunner",
-		"labels": {
-			"name": "testrunner"
-		}
-	},
-	"spec": {
-	    "terminationGracePeriodSeconds": 0,
-		"containers": [{
-			"name": "testrunner",
-			"readinessProbe" : {
-				"exec": {
-					"command": [
-					    "/bin/bash",
-					    "-c",
-					    "/opt/eap/bin/readinessProbe.sh"
-					]
-				}
-			},
-			"image": "jboss-eap-6/eap64-openshift:1.5",
+    "kind": "Pod",
+    "apiVersion":"v1",
+    "metadata": {
+        "name": "testrunner",
+        "labels": {
+            "name": "testrunner"
+        }
+    },
+    "spec": {
+        "terminationGracePeriodSeconds": 0,
+        "containers": [{
+            "name": "testrunner",
+            "readinessProbe" : {
+                "exec": {
+                    "command": [
+                        "/bin/bash",
+                        "-c",
+                        "/opt/eap/bin/readinessProbe.sh"
+                    ]
+                }
+            },
+            "image": "jboss-eap-6/eap64-openshift:1.5",
             "ports": [
                 {
                     "containerPort": 8080,
@@ -65,14 +65,14 @@
                     "value": ""
                 },
                 {
-                	"name": "ADMIN_USERNAME",
-                	"value": "admin"
+                    "name": "ADMIN_USERNAME",
+                    "value": "admin"
                 },
                 {
-                	"name": "ADMIN_PASSWORD",
-                	"value": "Admin#70365"
+                    "name": "ADMIN_PASSWORD",
+                    "value": "Admin#70365"
                 }
             ]
-		}]
-	}
+        }]
+    }
 }


### PR DESCRIPTION
    [KEYCLOAK-19272] Change non-groupified OpenShift API
    resources, referenced across various RH-SSO templates, test, and
    documentation files to their OpenShift API groupified counterparts
    
    Refer to particular entry of OCP v4.7 release notes:
    * https://docs.openshift.com/container-platform/4.7/release_notes/ocp-4-7-release-notes.html#ocp-4-7-apiversion-v1
    
    for additional details, background & motivation behind this change
    
    Note: The API objects belonging to the "core" API group (e.g. ConfigMap,
          Service, PersistentVolumeClaim, etc.) were intentionally omitted
          from this change (IOW the original group-less plain "v1" API group
          was left as apiVersion for them) to prevent raising 'unknown
          object type' errors, raised e.g. by 'oc new-app' when
          instantiating the templates
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
