### PR TITLE
KEYCLOAK-15633 SSL connection to DB

### DIFF
--- a/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -311,10 +311,14 @@ function generate_external_datasource() {
   fi
 
   if [ -n "$conn_properties" ]; then
-      prop_name=$(cut -d '=' -f 1 <<< "$conn_properties")
-      prop_value=$(cut -d '=' -f 2 <<< "$conn_properties")
+    properties_array=$(echo $conn_properties | tr ";")
+
+    for element in $properties_array; do
+      prop_name=$(cut -d '=' -f 1 <<< "$element")
+      prop_value=$(cut -d '=' -f 2 <<< "$element")
       ds="$ds
             <xa-datasource-property name=\"${prop_name}\">${prop_value}</xa-datasource-property>"
+    done
   fi
 
   if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then

--- a/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -311,7 +311,7 @@ function generate_external_datasource() {
   fi
 
   if [ -n "$conn_properties" ]; then
-    properties_array=$(echo $conn_properties | tr ";")
+    properties_array=$(echo $conn_properties | tr ";" "\n")
 
     for element in $properties_array; do
       prop_name=$(cut -d '=' -f 1 <<< "$element")

--- a/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -311,7 +311,7 @@ function generate_external_datasource() {
   fi
 
   if [ -n "$conn_properties" ]; then
-    properties_array=$(echo $conn_properties | tr ";" "\n")
+    properties_array=$(echo $conn_properties | tr ';' '\n' )
 
     for element in $properties_array; do
       prop_name=$(cut -d '=' -f 1 <<< "$element")

--- a/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -309,9 +309,8 @@ function generate_external_datasource() {
              <exception-sorter class-name=\"${sorter}\"></exception-sorter>
            </validation>"
   fi
-
   if [ -n "$conn_properties" ]; then
-    properties_array=$(echo $conn_properties | tr ';' '\n' )
+    properties_array=($(tr ';' '\n' <<< "${conn_properties}"))
 
     for element in $properties_array; do
       prop_name=$(cut -d '=' -f 1 <<< "$element")

--- a/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -314,7 +314,7 @@ function generate_external_datasource() {
       prop_name=$(cut -d '=' -f 1 <<< "$conn_properties")
       prop_value=$(cut -d '=' -f 2 <<< "$conn_properties")
       ds="$ds
-            <connection-property name=\"${prop_name}\">${prop_value}</connection-property>"
+            <xa-datasource-property name=\"${prop_name}\">${prop_value}</xa-datasource-property>"
   fi
 
   if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then

--- a/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/modules/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -166,7 +166,6 @@ function inject_external_datasources() {
 # $12 - datasource jta
 # $13 - validate
 # $14 - url
-# $15 - conn_property
 function generate_datasource_common() {
   local pool_name="${1}"
   local jndi_name="${2}"
@@ -508,7 +507,7 @@ function inject_datasource() {
   if [ -z "$driver" ]; then
     log_warning "DRIVER not set for datasource ${service_name}. Datasource will not be configured."
   else
-    datasource=$(generate_datasource "${service,,}-${prefix}" "$jndi" "$username" "$password" "$host" "$port" "$database" "$checker" "$sorter" "$driver" "$service_name" "$jta" "$validate" "$url" )
+    datasource=$(generate_datasource "${service,,}-${prefix}" "$jndi" "$username" "$password" "$host" "$port" "$database" "$checker" "$sorter" "$driver" "$service_name" "$jta" "$validate" "$url")
 
     if [ -n "$datasource" ]; then
       sed -i "s|<!-- ##DATASOURCES## -->|${datasource}\n<!-- ##DATASOURCES## -->|" $CONFIG_FILE

--- a/modules/os-eap-launch/added/launch/datasource-common.sh
+++ b/modules/os-eap-launch/added/launch/datasource-common.sh
@@ -322,7 +322,7 @@ function generate_external_datasource() {
       prop_name=$(cut -d '=' -f 1 <<< "$conn_properties")
       prop_value=$(cut -d '=' -f 2 <<< "$conn_properties")
       ds="$ds
-            <connection-property name=\"${prop_name}\">${prop_value}</connection-property>"
+            <xa-datasource-property name=\"${prop_name}\">${prop_value}</xa-datasource-property>"
   fi
 
   if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then

--- a/modules/os-eap-launch/added/launch/datasource-common.sh
+++ b/modules/os-eap-launch/added/launch/datasource-common.sh
@@ -38,6 +38,7 @@ function clearDatasourceEnv() {
   unset ${prefix}_URL
   unset ${prefix}_BACKGROUND_VALIDATION
   unset ${prefix}_BACKGROUND_VALIDATION_MILLIS
+  unset ${prefix}_CONN_PROPERTY
 
   for xa_prop in $(compgen -v | grep -s "${prefix}_XA_CONNECTION_PROPERTY_"); do
     unset ${xa_prop}
@@ -174,6 +175,7 @@ function inject_external_datasources() {
 # $12 - datasource jta
 # $13 - validate
 # $14 - url
+# $15 - conn_property
 function generate_datasource_common() {
   local pool_name="${1}"
   local jndi_name="${2}"
@@ -192,6 +194,7 @@ function generate_datasource_common() {
   local url="${14//&/\\&}"
   # CLOUD-3198 In addition to that, we also need to escape ';'
   url="${url//;/\\;}"
+  local conn_properties="${15}"
 
   if [ -n "$driver" ]; then
     ds=$(generate_external_datasource)
@@ -313,6 +316,13 @@ function generate_external_datasource() {
              <valid-connection-checker class-name=\"${checker}\"></valid-connection-checker>
              <exception-sorter class-name=\"${sorter}\"></exception-sorter>
            </validation>"
+  fi
+
+  if [ -n "$conn_properties" ]; then
+      prop_name=$(cut -d '=' -f 1 <<< "$conn_properties")
+      prop_value=$(cut -d '=' -f 2 <<< "$conn_properties")
+      ds="$ds
+            <connection-property name=\"${prop_name}\">${prop_value}</connection-property>"
   fi
 
   if [ -n "$NON_XA_DATASOURCE" ] && [ "$NON_XA_DATASOURCE" = "true" ]; then
@@ -449,6 +459,7 @@ function inject_datasource() {
   local sorter
   local url
   local service_name
+  local conn_properties
 
   host=$(find_env "${service}_SERVICE_HOST")
 
@@ -497,6 +508,8 @@ function inject_datasource() {
 
   url=$(find_env "${prefix}_URL")
 
+  conn_properties=$(find_env "${prefix}_CONN_PROPERTY")
+
   case "$db" in
     "MYSQL")
       map_properties "jdbc:mysql" "${prefix}_XA_CONNECTION_PROPERTY_ServerName" "${prefix}_XA_CONNECTION_PROPERTY_Port" "${prefix}_XA_CONNECTION_PROPERTY_DatabaseName"
@@ -537,7 +550,7 @@ function inject_datasource() {
   if [ -z "$driver" ]; then
     log_warning "DRIVER not set for datasource ${service_name}. Datasource will not be configured."
   else
-    datasource=$(generate_datasource "${service,,}-${prefix}" "$jndi" "$username" "$password" "$host" "$port" "$database" "$checker" "$sorter" "$driver" "$service_name" "$jta" "$validate" "$url")
+    datasource=$(generate_datasource "${service,,}-${prefix}" "$jndi" "$username" "$password" "$host" "$port" "$database" "$checker" "$sorter" "$driver" "$service_name" "$jta" "$validate" "$url" "$conn_properties")
 
     if [ -n "$datasource" ]; then
       sed -i "s|<!-- ##DATASOURCES## -->|${datasource}\n<!-- ##DATASOURCES## -->|" $CONFIG_FILE

--- a/modules/os-eap7-launch/added/launch/datasource.sh
+++ b/modules/os-eap7-launch/added/launch/datasource.sh
@@ -40,8 +40,9 @@ function generate_datasource() {
   local jta="${12}"
   local validate="${13}"
   local url="${14}"
+  local conn_properties="${15}"
 
-  generate_datasource_common "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${10}" "${11}" "${12}" "${13}" "${14}"
+  generate_datasource_common "${pool_name}" "${jndi_name}" "${username}" "${password}" "${host}" "${port}" "${databasename}" "${checker}" "${sorter}" "${driver}" "${service_name}" "${jta}" "${validate}" "${url}" "${conn_properties}"
 
   if [ -z "$service_name" ]; then
     service_name="ExampleDS"

--- a/modules/os-eap7-launch/added/launch/datasource.sh
+++ b/modules/os-eap7-launch/added/launch/datasource.sh
@@ -41,7 +41,7 @@ function generate_datasource() {
   local validate="${13}"
   local url="${14}"
 
-  generate_datasource_common "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${driver}" "${11}" "${12}" "${13}" "${14}"
+  generate_datasource_common "${pool_name}" "${jndi_name}" "${username}" "${password}" "${host}" "${port}" "${databasename}" "${checker}" "${sorter}" "${driver}" "${service_name}" "${jta}" "${validate}" "${url}"
 
   if [ -z "$service_name" ]; then
     service_name="ExampleDS"

--- a/modules/os-eap7-launch/added/launch/datasource.sh
+++ b/modules/os-eap7-launch/added/launch/datasource.sh
@@ -40,9 +40,8 @@ function generate_datasource() {
   local jta="${12}"
   local validate="${13}"
   local url="${14}"
-  local conn_properties="${15}"
 
-  generate_datasource_common "${pool_name}" "${jndi_name}" "${username}" "${password}" "${host}" "${port}" "${databasename}" "${checker}" "${sorter}" "${driver}" "${service_name}" "${jta}" "${validate}" "${url}" "${conn_properties}"
+  generate_datasource_common "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${driver}" "${11}" "${12}" "${13}" "${14}"
 
   if [ -z "$service_name" ]; then
     service_name="ExampleDS"

--- a/modules/os-eap7-launch/added/launch/tx-datasource.sh
+++ b/modules/os-eap7-launch/added/launch/tx-datasource.sh
@@ -72,7 +72,9 @@ function generate_tx_datasource() {
                       <security>
                           <user-name>${3}</user-name>
                           <password>${4}</password>
-                      </security>
+                      </security>"
+      ds="$ds
+                      ${SSLMODE_ENV_VAR}
                   </datasource>"
   echo $ds | sed ':a;N;$!ba;s|\n|\\n|g'
 }

--- a/modules/os-eap7-launch/added/launch/tx-datasource.sh
+++ b/modules/os-eap7-launch/added/launch/tx-datasource.sh
@@ -73,8 +73,19 @@ function generate_tx_datasource() {
                           <user-name>${3}</user-name>
                           <password>${4}</password>
                       </security>"
+
+      # Adding the properties in DB_XA_CONNECTION_PROPERTY_* as connection properties in lowercase
+      # e.g. DB_XA_CONNECTION_PROPERTY_sslMode=verify-ca --> sslmode=verify-ca
+      local xa_props=$(compgen -v | grep -s "${prefix}_XA_CONNECTION_PROPERTY_")
+      for xa_prop in $(echo $xa_props); do
+        prop_name=$(echo "${xa_prop}" | sed -e "s/${prefix}_XA_CONNECTION_PROPERTY_//g" | tr '[:upper:]' '[:lower:]')
+        prop_val=$(find_env $xa_prop)
+        if [ ! -z ${prop_val} ]; then
+          ds="$ds <connection-property name=\"${prop_name}\">${prop_val}</connection-property>"
+        fi
+      done
+
       ds="$ds
-                      ${SSLMODE_ENV_VAR}
                   </datasource>"
   echo $ds | sed ':a;N;$!ba;s|\n|\\n|g'
 }

--- a/modules/sso/config/launch/setup/74/added/launch/datasource.sh
+++ b/modules/sso/config/launch/setup/74/added/launch/datasource.sh
@@ -74,8 +74,9 @@ function generate_datasource() {
   local jta="${12}"
   local validate="${13}"
   local url="${14}"
+  local conn_properties="${15}"
 
-  generate_datasource_common "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${driver}" "${11}" "${12}" "${13}" "${14}"
+  generate_datasource_common "${pool_name}" "${jndi_name}" "${username}" "${password}" "${host}" "${port}" "${databasename}" "${checker}" "${sorter}" "${driver}" "${service_name}" "${jta}" "${validate}" "${url}" "${conn_properties}"
 
   if [ -z "$service_name" ]; then
     service_name="ExampleDS"

--- a/modules/sso/config/launch/setup/74/added/launch/datasource.sh
+++ b/modules/sso/config/launch/setup/74/added/launch/datasource.sh
@@ -74,9 +74,8 @@ function generate_datasource() {
   local jta="${12}"
   local validate="${13}"
   local url="${14}"
-  local conn_properties="${15}"
 
-  generate_datasource_common "${pool_name}" "${jndi_name}" "${username}" "${password}" "${host}" "${port}" "${databasename}" "${checker}" "${sorter}" "${driver}" "${service_name}" "${jta}" "${validate}" "${url}" "${conn_properties}"
+  generate_datasource_common "${pool_name}" "${jndi_name}" "${username}" "${password}" "${host}" "${port}" "${databasename}" "${checker}" "${sorter}" "${driver}" "${service_name}" "${jta}" "${validate}" "${url}"
 
   if [ -z "$service_name" ]; then
     service_name="ExampleDS"


### PR DESCRIPTION
Added new property to pass params to the database : %PREFIX%_CONN_PROPERTY that will be sent to datasource.connection-property in order to allow SSL connection to the DB.
https://issues.redhat.com/browse/KEYCLOAK-15633


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`

### Steps to Test
1. Build Image
    1. go to the jenkins server : /view/RH-SSO/job/rh-sso-pipeline-continuous_container
    2. check for last execution without "release" in the title
    3. rebuild 
        1. check these critical parameters
            1.  declare -x PIPELINE_EXECUTION_ID="keycloak-15633-sso74"  <-- id 
            2. declare -x IMAGE_OPENSHIFT_REPO="https://github.com/{your repo}/redhat-sso-7-openshift-image.git" <-- your repo with the changes
            3. declare -x IMAGE_OPENSHIFT_BRANCH="KEYCLOAK-15633-allow-ssl-to-db-sso74" <-- branch with changes
            4. declare -x RELEASE="false" <-- **WATCH** specifically this parameter that has to be "false" 
        2. check BUILD_OPENJDK , uncheck BUILD_OPENJ9
        3. clear IMAGE_STANDALONE and IMAGE_OPENSHIFT and IMAGE_OPENSHIFT_OPENJ9
        4. To make it faster ,  ~ 24 minutes instead of several hours
        5. When finished check the Full log and search for "image available as" and **copy the path** on redhat registry
2. Install SSO Operator on Openshift ( using the Operatorhub embedded screen )
    1.  go to the openshift keycloak playground
    2. login as admin
    3. install the SSO operator from the Operatorhub embedded
3. Modify the Operator Yaml ( the CSV ) setting the RELATED_IMAGE_SSO with that image created
    1. + install.spec.deployments.spec.template.spec.containers.env.RELATED_IMAGE_RHSSO= {redhat registry image url copied above}
4. Install CrunchyData Postgres Operator and pgo cli
    1.  https://access.crunchydata.com/documentation/postgres-operator/latest/quickstart/
5. Generate certificates and upload them locally
    1.  https://blog.crunchydata.com/blog/set-up-tls-for-postgresql-in-kubernetes
6. Create a truststore to be used by keycloak
    1.  considering previous steps created `ca.crt` and `server.crt`
    2. keytool -import -file server.crt -alias crunchy-server-cert -keystore truststore.jks
    3. keytool -import -file ca.crt -alias crunchy-ca-cert -keystore truststore.jks
7. Make this trustore available for keycloak
    1. kubectl create configmap sso-truststore-ssl --from-file=truststore.jks -n {your namespace}
8. Create Keycloak CR
    1. in the operator , keycloak tab,  KeycloakDeploymentSpec.Experimental
        1. add Env vars
            1. DB_CONN_PROPERTY=sslMode=require;ssl=true
            2. SCRIPT_DEBUG='true'
            3. KEYCLOAK_POSTGRESQL_SERVICE_HOST=hippo.pgo.svc.cluster.local
            4. DB_USERNAME=testuser
            5. DB_PASSWORD=test
            6. DB_DATABASE=hippo
            7. JAVA_OPTS_APPEND=-Djavax.net.ssl.trustStore=/opt/jboss/.postgresql/truststore.jks    -Djavax.net.ssl.trustStorePassword=nothing -Djavax.net.debug=all
        2. add volumes
            1. Configmap
            2. mount path /opt/jboss/.postgresql
            3. name sso-truststore-ssl
            4. items.key truststore.jks
            5. items.path truststore.jks
9. Check the SSL logs for the Keycloak pod , it should appear some DELETE or SELECT queries inside SSL blocks
```
  0000: 50 00 00 00 35 00 53 45   4C 45 43 54 20 49 44 20  P...5.SELECT ID 
  0010: 46 52 4F 4D 20 74 65 73   74 75 73 65 72 2E 64 61  FROM testuser.da
  0020: 74 61 62 61 73 65 63 68   61 6E 67 65 6C 6F 67 6C  tabasechangelogl
   0030: 6F 63 6B 00 00 00 42 00   00 00 0C 00 00 00 00 00  ock...B.........
   0040: 00 00 00 44 00 00 00 06   50 00 45 00 00 00 09 00  ...D....P.E.....
   0050: 00 00 00 00 53 00 00 00   04 17 00 00 00 00 00 00  ....S...........
   0060: 00 00 00 00 00 00 00 00   00 00                                        ..........```