### PR TITLE
[KEYCLOAK-18896] For the API objects, belonging to the "core" group, return the groupified "core/v1" apiVersion field expression back to the group-less (plain) "v1" form

### DIFF
--- a/template.adoc.in
+++ b/template.adoc.in
@@ -215,7 +215,7 @@ For DNS_PING to work, the following steps must be taken:
 [source,yaml]
 ----
 kind: Service
-apiVersion: core/v1
+apiVersion: v1
 spec:
     clusterIP: None
     ports:

--- a/templates/openj9/sso74-openj9-https.json
+++ b/templates/openj9/sso74-openj9-https.json
@@ -214,7 +214,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -238,7 +238,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -262,7 +262,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/openj9/sso74-openj9-ocp4-x509-https.json
+++ b/templates/openj9/sso74-openj9-ocp4-x509-https.json
@@ -116,7 +116,7 @@
     "objects": [
         {
             "kind": "ConfigMap",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -130,7 +130,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -155,7 +155,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/openj9/sso74-openj9-ocp4-x509-postgresql-persistent.json
+++ b/templates/openj9/sso74-openj9-ocp4-x509-postgresql-persistent.json
@@ -171,7 +171,7 @@
     ],
     "objects": [
         {
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "kind": "ConfigMap",
             "metadata": {
                 "annotations": {
@@ -186,7 +186,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -212,7 +212,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -236,7 +236,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -628,7 +628,7 @@
         },
         {
             "kind": "PersistentVolumeClaim",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/openj9/sso74-openj9-postgresql-persistent.json
+++ b/templates/openj9/sso74-openj9-postgresql-persistent.json
@@ -270,7 +270,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -295,7 +295,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -320,7 +320,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -344,7 +344,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -804,7 +804,7 @@
         },
         {
             "kind": "PersistentVolumeClaim",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/openj9/sso74-openj9-postgresql.json
+++ b/templates/openj9/sso74-openj9-postgresql.json
@@ -263,7 +263,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -289,7 +289,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -315,7 +315,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -340,7 +340,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/openj9/sso74-openj9-x509-https.json
+++ b/templates/openj9/sso74-openj9-x509-https.json
@@ -116,7 +116,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -141,7 +141,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/openj9/sso74-openj9-x509-postgresql-persistent.json
+++ b/templates/openj9/sso74-openj9-x509-postgresql-persistent.json
@@ -172,7 +172,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -198,7 +198,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -222,7 +222,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -603,7 +603,7 @@
         },
         {
             "kind": "PersistentVolumeClaim",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso74-https.json
+++ b/templates/sso74-https.json
@@ -214,7 +214,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -238,7 +238,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -262,7 +262,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/sso74-ocp4-x509-https.json
+++ b/templates/sso74-ocp4-x509-https.json
@@ -116,7 +116,7 @@
     "objects": [
         {
             "kind": "ConfigMap",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -130,7 +130,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -155,7 +155,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/sso74-ocp4-x509-postgresql-persistent.json
+++ b/templates/sso74-ocp4-x509-postgresql-persistent.json
@@ -172,7 +172,7 @@
     "objects": [
         {
             "kind": "ConfigMap",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "annotations": {
                     "description": "ConfigMap providing service ca bundle.",
@@ -186,7 +186,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -212,7 +212,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -236,7 +236,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -628,7 +628,7 @@
         },
         {
             "kind": "PersistentVolumeClaim",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso74-postgresql-persistent.json
+++ b/templates/sso74-postgresql-persistent.json
@@ -270,7 +270,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -295,7 +295,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -320,7 +320,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -344,7 +344,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -804,7 +804,7 @@
         },
         {
             "kind": "PersistentVolumeClaim",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/templates/sso74-postgresql.json
+++ b/templates/sso74-postgresql.json
@@ -263,7 +263,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -289,7 +289,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -315,7 +315,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -340,7 +340,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/sso74-x509-https.json
+++ b/templates/sso74-x509-https.json
@@ -116,7 +116,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -141,7 +141,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [

--- a/templates/sso74-x509-postgresql-persistent.json
+++ b/templates/sso74-x509-postgresql-persistent.json
@@ -172,7 +172,7 @@
     "objects": [
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -198,7 +198,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "ports": [
                     {
@@ -222,7 +222,7 @@
         },
         {
             "kind": "Service",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "spec": {
                 "clusterIP": "None",
                 "ports": [
@@ -603,7 +603,7 @@
         },
         {
             "kind": "PersistentVolumeClaim",
-            "apiVersion": "core/v1",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-postgresql-claim",
                 "labels": {

--- a/tests/arq/src/test/java/org/jboss/test/arquillian/ce/sso/SsoVaultTest.java
+++ b/tests/arq/src/test/java/org/jboss/test/arquillian/ce/sso/SsoVaultTest.java
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.not;
         })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/sso-app-secret.json")
 @OpenShiftResource("{\n" +
-        "  \"apiVersion\": \"core/v1\",\n" +
+        "  \"apiVersion\": \"v1\",\n" +
         "  \"data\": {\n" +
         "    \"master_smtp__password\": \"bXlTTVRQUHNzd2Q=\"\n" +
         "  },\n" +

--- a/tests/arq/src/test/resources/testrunner-pod.json
+++ b/tests/arq/src/test/resources/testrunner-pod.json
@@ -1,6 +1,6 @@
 {
     "kind": "Pod",
-    "apiVersion":"core/v1",
+    "apiVersion":"v1",
     "metadata": {
         "name": "testrunner",
         "labels": {


### PR DESCRIPTION
    [KEYCLOAK-18896] For the API objects, belonging to the "core" group,
    return the groupified "core/v1" apiVersion field expression back
    to the group-less (plain) "v1" form, since the former is raising
    unknown object type errors by, e.g. "oc new-app" when such API
    objects are processed
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
