### PR TITLE
[KEYCLOAK-19558] Update ha.sh

### DIFF
--- a/modules/eap/setup/eap/modules/added/launch/ha.sh
+++ b/modules/eap/setup/eap/modules/added/launch/ha.sh
@@ -289,7 +289,7 @@ generate_dns_ping_config() {
 
 configure_ha_args() {
   # Set HA args
-  IP_ADDR=`hostname -i`
+  IP_ADDR=`hostname -i | cut -d " " -f1`
   JBOSS_HA_ARGS="-b ${JBOSS_HA_IP:-${IP_ADDR}} -bprivate ${JBOSS_HA_IP:-${IP_ADDR}}"
 
   init_node_name


### PR DESCRIPTION
On a dual-stack OpenShift cluster the command 'hostname -i' gives two IPs back. We only need one IP, either IPv4 or IPv6, to build JBOSS_HA_ARGS.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ x] Pull Request contains link to the JIRA issue
https://issues.redhat.com/browse/KEYCLOAK-19558
- [ x] Pull Request contains a description of the issue
On a dual-stack openshift cluster the command 'hostname -i' returns both IPs (IPv4 and IPv6). To fill IP_ADDR. That var IP_ADDR is directly used to build the var JBOSS_HA_ARG. So we get a double IP while it should be one IP.
- [x ] Pull Request does not include fixes for issues other than the main ticket
- [ x] Attached commits represent units of work and are properly formatted
- [ x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
