### PR TITLE
[CIAM-1394] Use a non-printable character, ASCII unit separator as the sed substitute command delimiter character

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -94,6 +94,14 @@ modules:
             path: modules
 
       install:
+          # Define RH-SSO global variables & functions required by subsequent image modules.
+          #
+          # IMPORTANT: This module needs to be included (sourced) in each of the following
+          #            modules using "sed -e" or "sed -i" expressions, where the regex pattern
+          #            or the replacement value is dynamic (coming from env var supplied to the
+          #            container image at runtime). See CIAM-1394 JIRA for details
+          - name: sso.rcfile
+            version: '1.0'
           - name: sso.security.cve-2020-10695
             version: '1.0'
           # Install JDK runtime

--- a/modules/eap/setup/eap/modules/added/https.sh
+++ b/modules/eap/setup/eap/modules/added/https.sh
@@ -69,7 +69,9 @@ function configureSslXml() {
             </ssl>\n\
         </server-identities>"
 
-  sed -i "s|<!-- ##SSL## -->|${ssl}|" $CONFIG_FILE
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ##SSL## -->${AUS}${ssl}${AUS}" $CONFIG_FILE
+  # EOF CIAM-1394 correction
 }
 
 function configureSslCli() {
@@ -96,7 +98,9 @@ EOF
 
 function configureHttpsXml() {
   https_connector="<https-listener name=\"https\" socket-binding=\"https\" security-realm=\"ApplicationRealm\" proxy-address-forwarding=\"true\"/>"
-  sed -i "s|<!-- ##HTTPS_CONNECTOR## -->|${https_connector}|" $CONFIG_FILE
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ##HTTPS_CONNECTOR## -->${AUS}${https_connector}${AUS}" $CONFIG_FILE
+  # EOF CIAM-1394 correction
 }
 
 function configureHttpsCli() {

--- a/modules/eap/setup/eap/modules/added/keycloak.sh
+++ b/modules/eap/setup/eap/modules/added/keycloak.sh
@@ -162,7 +162,9 @@ function configure_cli_keycloak() {
           keycloak_subsystem=$(cat "${SECURE_DEPLOYMENTS}" | sed ':a;N;$!ba;s/\n//g')
           keycloak_subsystem="<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\">${keycloak_subsystem}</subsystem>${SUBSYSTEM_END_MARKER}"
 
-          sed -i "s|${SUBSYSTEM_END_MARKER}|${keycloak_subsystem}|" "${CONFIG_FILE}"
+          # CIAM-1394 correction
+          sed -i "s${AUS}${SUBSYSTEM_END_MARKER}${AUS}${keycloak_subsystem}${AUS}" "${CONFIG_FILE}"
+          # EOF CIAM-1394 correction
 
           oidc_elytron="$(configure_OIDC_elytron $id)"
           ejb_config="$(configure_ejb $id $app_sec_domain)"
@@ -183,7 +185,9 @@ function configure_cli_keycloak() {
           keycloak_subsystem=$(cat "${SECURE_SAML_DEPLOYMENTS}" | sed ':a;N;$!ba;s/\n//g')
           keycloak_subsystem="<subsystem xmlns=\"urn:jboss:domain:keycloak-saml:1.1\">${keycloak_subsystem}</subsystem>${SUBSYSTEM_END_MARKER}"
 
-          sed -i "s|${SUBSYSTEM_END_MARKER}|${keycloak_subsystem}|" "${CONFIG_FILE}"
+          # CIAM-1394 correction
+          sed -i "s${AUS}${SUBSYSTEM_END_MARKER}${AUS}${keycloak_subsystem}${AUS}" "${CONFIG_FILE}"
+          # EOF CIAM-1394 correction
 
           saml_elytron="$(configure_SAML_elytron $id)"
           if [ "$useLegacySecurity" == "false" ]; then
@@ -554,14 +558,18 @@ function configure_keycloak() {
       keycloak_subsystem=$(cat "${SECURE_DEPLOYMENTS}" | sed ':a;N;$!ba;s/\n//g')
       keycloak_subsystem="<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\">${keycloak_subsystem}</subsystem>"
 
-      sed -i "s|<!-- ##KEYCLOAK_SUBSYSTEM## -->|${keycloak_subsystem}|" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##KEYCLOAK_SUBSYSTEM## -->${AUS}${keycloak_subsystem}${AUS}" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
     fi
 
     if [ -f $SECURE_SAML_DEPLOYMENTS ]; then
       keycloak_subsystem=$(cat "${SECURE_SAML_DEPLOYMENTS}" | sed ':a;N;$!ba;s/\n//g')
       keycloak_subsystem="<subsystem xmlns=\"urn:jboss:domain:keycloak-saml:1.1\">${keycloak_subsystem}</subsystem>"
 
-      sed -i "s|<!-- ##KEYCLOAK_SAML_SUBSYSTEM## -->|${keycloak_subsystem}|" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##KEYCLOAK_SAML_SUBSYSTEM## -->${AUS}${keycloak_subsystem}${AUS}" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
     fi
 
     enable_keycloak_deployments
@@ -590,31 +598,45 @@ function configure_keycloak() {
     keycloak_saml_sp=$(cat "${KEYCLOAK_SAML_SP_SUBSYSTEM_FILE}" | sed ':a;N;$!ba;s|\n|\\n|g')
     configure_subsystem $SAML ${KEYCLOAK_SAML_REALM_SUBSYSTEM_FILE} "##KEYCLOAK_SAML_SUBSYSTEM##" "saml" ${KEYCLOAK_SAML_DEPLOYMENT_SUBSYSTEM_FILE}
 
-    sed -i "s|##KEYCLOAK_REALM##|${SSO_REALM}|g" "${CONFIG_FILE}"
+    # CIAM-1394 correction
+    sed -i "s${AUS}##KEYCLOAK_REALM##${AUS}${SSO_REALM}${AUS}g" "${CONFIG_FILE}"
+    # EOF CIAM-1394 correction
 
     if [ -n "$SSO_PUBLIC_KEY" ]; then
-      sed -i "s|<!-- ##KEYCLOAK_PUBLIC_KEY## -->|<realm-public-key>${SSO_PUBLIC_KEY}</realm-public-key>|g" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##KEYCLOAK_PUBLIC_KEY## -->${AUS}<realm-public-key>${SSO_PUBLIC_KEY}</realm-public-key>${AUS}g" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
     fi
 
     if [ -n "$SSO_TRUSTSTORE" ] && [ -n "$SSO_TRUSTSTORE_DIR" ]; then
-      sed -i "s|<!-- ##KEYCLOAK_TRUSTSTORE## -->|<truststore>${SSO_TRUSTSTORE_DIR}/${SSO_TRUSTSTORE}</truststore><truststore-password>${SSO_TRUSTSTORE_PASSWORD}</truststore-password>|g" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##KEYCLOAK_TRUSTSTORE## -->${AUS}<truststore>${SSO_TRUSTSTORE_DIR}/${SSO_TRUSTSTORE}</truststore><truststore-password>${SSO_TRUSTSTORE_PASSWORD}</truststore-password>${AUS}g" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
       sed -i "s|##KEYCLOAK_DISABLE_TRUST_MANAGER##|false|g" "${CONFIG_FILE}"
     else
       sed -i "s|##KEYCLOAK_DISABLE_TRUST_MANAGER##|true|g" "${CONFIG_FILE}"
     fi
 
-    sed -i "s|##KEYCLOAK_URL##|${SSO_URL}|g" "${CONFIG_FILE}"
+    # CIAM-1394 correction
+    sed -i "s${AUS}##KEYCLOAK_URL##${AUS}${SSO_URL}${AUS}g" "${CONFIG_FILE}"
+    # EOF CIAM-1394 correction
 
     if [ -n "$SSO_SAML_CERTIFICATE_NAME" ]; then
-      sed -i "s|##SSO_SAML_CERTIFICATE_NAME##|${SSO_SAML_CERTIFICATE_NAME}|g" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}##SSO_SAML_CERTIFICATE_NAME##${AUS}${SSO_SAML_CERTIFICATE_NAME}${AUS}g" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
     fi
 
     if [ -n "$SSO_SAML_KEYSTORE_PASSWORD" ]; then
-      sed -i "s|##SSO_SAML_KEYSTORE_PASSWORD##|${SSO_SAML_KEYSTORE_PASSWORD}|g" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}##SSO_SAML_KEYSTORE_PASSWORD##${AUS}${SSO_SAML_KEYSTORE_PASSWORD}${AUS}g" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
     fi
 
     if [ -n "$SSO_SAML_KEYSTORE" ] && [ -n "$SSO_SAML_KEYSTORE_DIR" ]; then
-      sed -i "s|##SSO_SAML_KEYSTORE##|${SSO_SAML_KEYSTORE_DIR}/${SSO_SAML_KEYSTORE}|g" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}##SSO_SAML_KEYSTORE##${AUS}${SSO_SAML_KEYSTORE_DIR}/${SSO_SAML_KEYSTORE}${AUS}g" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
     fi
   else
     log_warning "Missing SSO_URL. Unable to properly configure SSO-enabled applications"
@@ -661,7 +683,9 @@ function explode_keycloak_deployments() {
 
     if [ -f "${JBOSS_HOME}/standalone/deployments/${sso_deployment}/WEB-INF/web.xml" ]; then
       requested_auth_method=$(cat ${JBOSS_HOME}/standalone/deployments/${sso_deployment}/WEB-INF/web.xml | xmllint --nowarning --xpath "string(//*[local-name()='auth-method'])" - | sed ':a;N;$!ba;s/\n//g' | tr -d '[:space:]')
-      sed -i "s|${requested_auth_method}|${auth_method}|" "${JBOSS_HOME}/standalone/deployments/${sso_deployment}/WEB-INF/web.xml"
+      # CIAM-1394 correction
+      sed -i "s${AUS}${requested_auth_method}${AUS}${auth_method}${AUS}" "${JBOSS_HOME}/standalone/deployments/${sso_deployment}/WEB-INF/web.xml"
+      # EOF CIAM-1394 correction
     fi
   done
 }
@@ -694,12 +718,16 @@ function configure_extension() {
 }
 
 function configure_extensions_no_marker() {
-  sed -i "s|${EXTENSIONS_END_MARKER}|<extension module=\"org.keycloak.keycloak-adapter-subsystem\"/><extension module=\"org.keycloak.keycloak-saml-adapter-subsystem\"/>${EXTENSIONS_END_MARKER}|" "${CONFIG_FILE}"
+  # CIAM-1394 correction
+  sed -i "s${AUS}${EXTENSIONS_END_MARKER}${AUS}<extension module=\"org.keycloak.keycloak-adapter-subsystem\"/><extension module=\"org.keycloak.keycloak-saml-adapter-subsystem\"/>${EXTENSIONS_END_MARKER}${AUS}" "${CONFIG_FILE}"
+  # EOF CIAM-1394 correction
 }
 
 function configure_security_domain() {
   keycloak_security_domain=$(cat "${KEYCLOAK_SECURITY_DOMAIN_FILE}" | sed ':a;N;$!ba;s|\n|\\n|g')
-  sed -i "s|<!-- ##KEYCLOAK_SECURITY_DOMAIN## -->|${keycloak_security_domain%$'\n'}|" "${CONFIG_FILE}"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ##KEYCLOAK_SECURITY_DOMAIN## -->${AUS}${keycloak_security_domain%$'\n'}${AUS}" "${CONFIG_FILE}"
+  # EOF CIAM-1394 correction
 }
 
 function configure_subsystem() {
@@ -975,7 +1003,9 @@ function configure_subsystem() {
 
   if [ -z "$is_cli" ]; then
     if [ -n "$subsystem" ]; then
-      sed -i "s|<!-- ${subsystem_marker} -->|${subsystem%$'\n'}|" "${CONFIG_FILE}"
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ${subsystem_marker} -->${AUS}${subsystem%$'\n'}${AUS}" "${CONFIG_FILE}"
+      # EOF CIAM-1394 correction
     fi
   fi
 }

--- a/modules/eap/setup/eap/modules/added/launch/access_log_valve.sh
+++ b/modules/eap/setup/eap/modules/added/launch/access_log_valve.sh
@@ -46,7 +46,9 @@ function configure_access_log_valve() {
     if [ "${mode}" == "xml" ]; then
       local pattern=$(getPattern "add-xml")
       local valve="<access-log use-server-log=\"true\" pattern=\"${pattern}\"/>"
-      sed -i "s|<!-- ##ACCESS_LOG_VALVE## -->|${valve}|" $CONFIG_FILE
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##ACCESS_LOG_VALVE## -->${AUS}${valve}${AUS}" $CONFIG_FILE
+      # EOF CIAM-1394 correction
     else
             # A lot of XPath here since we need to do more advanced stuff than CLI allows us to...
 
@@ -184,7 +186,9 @@ function configure_access_log_handler() {
     getConfigurationMode "<!-- ##ACCESS_LOG_HANDLER## -->" "mode"
 
     if [ "${mode}" = "xml" ]; then
-      sed -i "s|<!-- ##ACCESS_LOG_HANDLER## -->|<logger category=\"${log_category}\"><level name=\"TRACE\"/></logger>|" $CONFIG_FILE
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##ACCESS_LOG_HANDLER## -->${AUS}<logger category=\"${log_category}\"><level name=\"TRACE\"/></logger>${AUS}" $CONFIG_FILE
+      # EOF CIAM-1394 correction
     elif [ "${mode}" = "cli" ]; then
 
       if [ -z "${ENABLE_ACCESS_LOG_TRACE}" ] || [ "${ENABLE_ACCESS_LOG_TRACE^^}" != "TRUE" ]; then

--- a/modules/eap/setup/eap/modules/added/launch/admin.sh
+++ b/modules/eap/setup/eap/modules/added/launch/admin.sh
@@ -33,7 +33,9 @@ function configure_administration() {
 
     if [ "${mode}" = "xml" ]; then
       local mgmt_iface_replace_str="security-realm=\"ManagementRealm\""
-      sed -i "s|><!-- ##MGMT_IFACE_REALM## -->| ${mgmt_iface_replace_str}>|" "$CONFIG_FILE"
+      # CIAM-1394 correction
+      sed -i "s${AUS}><!-- ##MGMT_IFACE_REALM## -->${AUS} ${mgmt_iface_replace_str}>${AUS}" "$CONFIG_FILE"
+      # EOF CIAM-1394 correction
     elif [ "${mode}" = "cli" ]; then
       cat << EOF >> "${CLI_SCRIPT_FILE}"
       if (outcome != success) of /core-service=management/management-interface=http-interface:read-resource

--- a/modules/eap/setup/eap/modules/added/launch/datasource-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/datasource-common.sh
@@ -109,7 +109,9 @@ function inject_internal_datasources() {
       local dsConfMode
       getDataSourceConfigureMode "dsConfMode"
       if [ "${dsConfMode}" = "xml" ]; then
-        sed -i "s|<!-- ##DATASOURCES## -->|${datasource}<!-- ##DATASOURCES## -->|" $CONFIG_FILE
+        # CIAM-1394 correction
+        sed -i "s${AUS}<!-- ##DATASOURCES## -->${AUS}${datasource}<!-- ##DATASOURCES## -->${AUS}" $CONFIG_FILE
+        # EOF CIAM-1394 correction
       elif [ "${dsConfMode}" = "cli" ]; then
         echo "${datasource}" >> ${CLI_SCRIPT_FILE}
       fi
@@ -198,9 +200,11 @@ function writeEEDefaultDatasourceXml() {
     defaultDatasource=""
   fi
   # new format replacement : datasource="##DEFAULT_DATASOURCE##"
-  sed -i "s|datasource=\"##DEFAULT_DATASOURCE##\"|${defaultDatasource}|" $CONFIG_FILE
+  # CIAM-1394 correction
+  sed -i "s${AUS}datasource=\"##DEFAULT_DATASOURCE##\"${AUS}${defaultDatasource}${AUS}" $CONFIG_FILE
   # old format (for compat)
-  sed -i "s|<!-- ##DEFAULT_DATASOURCE## -->|${defaultDatasource}|" $CONFIG_FILE
+  sed -i "s${AUS}<!-- ##DEFAULT_DATASOURCE## -->${AUS}${defaultDatasource}${AUS}" $CONFIG_FILE
+  # EOF CIAM-1394 correction
 }
 
 function writeEEDefaultDatasourceCli() {
@@ -416,7 +420,9 @@ function inject_connection_properties_to_datasource_xml() {
 
   if [ "${failed}" != "true" ]; then
     for property in "${conn_props[@]}"; do
-      prop_name=$(sed -e "s/${conn_prop_env_var}//g" <<< "${property}")
+      # CIAM-1394 correction
+      prop_name=$(sed -e "s${AUS}${conn_prop_env_var}${AUS}${AUS}g" <<< "${property}")
+      # EOF CIAM-1394 correction
       prop_value=$(find_env "${property}")
       if [ ! -z "${prop_value}" ]; then
           ds="${ds}
@@ -588,7 +594,9 @@ function generate_external_datasource_cli() {
     else
       if [ "${failed}" != "true" ]; then
         for property in "${conn_props[@]}"; do
-          prop_name=$(sed -e "s/${conn_prop_env_var}//g" <<< "${property}")
+          # CIAM-1394 correction
+          prop_name=$(sed -e "s${AUS}${conn_prop_env_var}${AUS}${AUS}g" <<< "${property}")
+          # EOF CIAM-1394 correction
           prop_value=$(find_env "${property}")
           if [ ! -z "${prop_value}" ]; then
             ds_tmp_connection_properties["${prop_name}"]="${prop_value}"
@@ -758,7 +766,9 @@ function inject_default_timer_service() {
                       <file-data-store name=\"default-file-store\" path=\"timer-service-data\" relative-to=\"jboss.server.data.dir\"/>\
                   </data-stores>\
               </timer-service>"
-    sed -i "s|<!-- ##TIMER_SERVICE## -->|${timerservice}|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##TIMER_SERVICE## -->${AUS}${timerservice}${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
 
     # We will use this file for validation later, so write here that we found a match
     touch "${TIMER_SERVICE_DATA_STORE_FILE}"
@@ -805,7 +815,9 @@ function inject_timer_service() {
                     <database-data-store name=\"${datastore_name}\" datasource-jndi-name=\"${jndi_name}\" database=\"${databasename}\" partition=\"${pool_name}_part\" refresh-interval=\"${refresh_interval}\"/>
                   </data-stores>\
               </timer-service>"
-    sed -i "s|<!-- ##TIMER_SERVICE## -->|${timerservice}|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##TIMER_SERVICE## -->${AUS}${timerservice}${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
 
     # We will use this file for validation later, so write here that we found a match
     touch "${TIMER_SERVICE_DATA_STORE_FILE}"
@@ -1047,7 +1059,9 @@ function inject_datasource() {
       local dsConfMode
       getDataSourceConfigureMode "dsConfMode"
       if [ "${dsConfMode}" = "xml" ]; then
-        sed -i "s|<!-- ##DATASOURCES## -->|${datasource}\n<!-- ##DATASOURCES## -->|" $CONFIG_FILE
+        # CIAM-1394 correction
+        sed -i "s${AUS}<!-- ##DATASOURCES## -->${AUS}${datasource}\n<!-- ##DATASOURCES## -->${AUS}" $CONFIG_FILE
+        # EOF CIAM-1394 correction
       elif [ "${dsConfMode}" = "cli" ]; then
         echo "${datasource}" >> ${CLI_SCRIPT_FILE}
       fi
@@ -1073,7 +1087,9 @@ function inject_default_job_repository() {
   getConfigurationMode "<!-- ##DEFAULT_JOB_REPOSITORY## -->" "dsConfMode"
   if [ "${dsConfMode}" = "xml" ]; then
     local defaultjobrepo="     <default-job-repository name=\"${1}\"/>"
-    sed -i "s|<!-- ##DEFAULT_JOB_REPOSITORY## -->|${defaultjobrepo%$'\n'}|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##DEFAULT_JOB_REPOSITORY## -->${AUS}${defaultjobrepo%$'\n'}${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
 
     # We will use this file for validation later, so create it to indicate we found a match
     touch "${DEFAULT_JOB_REPOSITORY_FILE}"
@@ -1115,7 +1131,9 @@ function inject_job_repository() {
       </job-repository>\
       <!-- ##JOB_REPOSITORY## -->"
 
-    sed -i "s|<!-- ##JOB_REPOSITORY## -->|${jobrepo%$'\n'}|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##JOB_REPOSITORY## -->${AUS}${jobrepo%$'\n'}${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
 
     # We will use this file for validation later, so create it to indicate we found a match
     touch "${DEFAULT_JOB_REPOSITORY_FILE}"

--- a/modules/eap/setup/eap/modules/added/launch/datasource.sh
+++ b/modules/eap/setup/eap/modules/added/launch/datasource.sh
@@ -37,7 +37,9 @@ function configureEnv() {
   # TODO - I don't think this is being used any more? The real action seems to be in tx-datasource.sh
   if [ -n "$JDBC_STORE_JNDI_NAME" ]; then
     local jdbcStore="<jdbc-store datasource-jndi-name=\"${JDBC_STORE_JNDI_NAME}\"/>"
-    sed -i "s|<!-- ##JDBC_STORE## -->|${jdbcStore}|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##JDBC_STORE## -->${AUS}${jdbcStore}${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
   fi
 
 }

--- a/modules/eap/setup/eap/modules/added/launch/deploymentScanner.sh
+++ b/modules/eap/setup/eap/modules/added/launch/deploymentScanner.sh
@@ -8,7 +8,9 @@ function configure_deployment_scanner() {
   local auto_deploy_exploded
   local explicitly_set=false
   if [[ -n "$JAVA_OPTS_APPEND" ]] && [[ $JAVA_OPTS_APPEND == *"Xdebug"* ]]; then
-    sed -i "s|##AUTO_DEPLOY_EXPLODED##|true|" "$CONFIG_FILE"
+    # CIAM-1394 correction
+    sed -i "s${AUS}##AUTO_DEPLOY_EXPLODED##${AUS}true${AUS}" "$CONFIG_FILE"
+    # EOF CIAM-1394 correction
     auto_deploy_exploded=true
   elif [ -n "$AUTO_DEPLOY_EXPLODED" ] || [ -n "$OPENSHIFT_AUTO_DEPLOY_EXPLODED" ]; then
     auto_deploy_exploded="${AUTO_DEPLOY_EXPLODED:-${OPENSHIFT_AUTO_DEPLOY_EXPLODED}}"
@@ -22,7 +24,9 @@ function configure_deployment_scanner() {
   getConfigurationMode "##AUTO_DEPLOY_EXPLODED##" "configure_mode"
 
   if [ "${configure_mode}" = "xml" ]; then
-    sed -i "s|##AUTO_DEPLOY_EXPLODED##|${auto_deploy_exploded}|" "$CONFIG_FILE"
+    # CIAM-1394 correction
+    sed -i "s${AUS}##AUTO_DEPLOY_EXPLODED##${AUS}${auto_deploy_exploded}${AUS}" "$CONFIG_FILE"
+    # EOF CIAM-1394 correction
   elif [ "${configure_mode}" = "cli" ] && [ "${explicitly_set}" = "true" ]; then
     # We only do this if the variable was explicitly set. Otherwise we assume the user has provided their own configuration
 

--- a/modules/eap/setup/eap/modules/added/launch/elytron.sh
+++ b/modules/eap/setup/eap/modules/added/launch/elytron.sh
@@ -69,9 +69,13 @@ insert_elytron_tls() {
          </tls>\n"
     # check for new config tag, use that if it's present, note we remove the <!-- ##ELYTRON_TLS## --> on first substitution
     if [ "true" = $(has_elytron_tls "${CONFIG_FILE}") ]; then
-        sed -i "s|<!-- ##ELYTRON_TLS## -->|${elytron_tls}|" $CONFIG_FILE
+        # CIAM-1394 correction
+        sed -i "s${AUS}<!-- ##ELYTRON_TLS## -->${AUS}${elytron_tls}${AUS}" $CONFIG_FILE
+        # EOF CIAM-1394 correction
         # remove the legacy tag, if it's present
-        sed -i "s|<!-- ##TLS## -->||" $CONFIG_FILE
+        # CIAM-1394 correction
+        sed -i "s${AUS}<!-- ##TLS## -->${AUS}${AUS}" $CONFIG_FILE
+        # EOF CIAM-1394 correction
     fi
 }
 
@@ -289,14 +293,18 @@ configure_https() {
           # insert the new config element, only if it hasn't been added already
           insert_elytron_tls_config_if_needed "${CONFIG_FILE}"
           # insert the individual config blocks we leave the replacement tags around in case something else (e.g. jgoups might need to add a keystore etc)
-          sed -i "s|<!-- ##ELYTRON_KEY_STORE## -->|${elytron_key_store}<!-- ##ELYTRON_KEY_STORE## -->|" $CONFIG_FILE
-          sed -i "s|<!-- ##ELYTRON_KEY_MANAGER## -->|${elytron_key_manager}<!-- ##ELYTRON_KEY_MANAGER## -->|" $CONFIG_FILE
-          sed -i "s|<!-- ##ELYTRON_SERVER_SSL_CONTEXT## -->|${elytron_server_ssl_context}<!-- ##ELYTRON_SERVER_SSL_CONTEXT## -->|" $CONFIG_FILE
+          # CIAM-1394 correction
+          sed -i "s${AUS}<!-- ##ELYTRON_KEY_STORE## -->${AUS}${elytron_key_store}<!-- ##ELYTRON_KEY_STORE## -->${AUS}" $CONFIG_FILE
+          sed -i "s${AUS}<!-- ##ELYTRON_KEY_MANAGER## -->${AUS}${elytron_key_manager}<!-- ##ELYTRON_KEY_MANAGER## -->${AUS}" $CONFIG_FILE
+          sed -i "s${AUS}<!-- ##ELYTRON_SERVER_SSL_CONTEXT## -->${AUS}${elytron_server_ssl_context}<!-- ##ELYTRON_SERVER_SSL_CONTEXT## -->${AUS}" $CONFIG_FILE
+          # EOF CIAM-1394 correction
       else # legacy config
           legacy_elytron_tls=$(elytron_legacy_config "${elytron_key_store}" "${elytron_key_manager}" "${elytron_server_ssl_context}")
       fi
       # will be empty unless only the old marker is present.
-      sed -i "s|<!-- ##TLS## -->|${legacy_elytron_tls}|" $CONFIG_FILE
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##TLS## -->${AUS}${legacy_elytron_tls}${AUS}" $CONFIG_FILE
+      # EOF CIAM-1394 correction
     elif [ ${use_tls_cli} -eq 1 ]; then
       create_elytron_keystore_cli "LocalhostKeyStore" "${HTTPS_KEYSTORE}" "${HTTPS_PASSWORD}" "${HTTPS_KEYSTORE_TYPE}" "${HTTPS_KEYSTORE_DIR}"
       create_elytron_keymanager_cli "LocalhostKeyManager" "LocalhostKeyStore" "${key_password}"
@@ -307,7 +315,9 @@ configure_https() {
     getConfigurationMode "<!-- ##HTTPS_CONNECTOR## -->" "elytron_https_connector_conf_mode"
     if [ "${elytron_https_connector_conf_mode}" = "xml" ]; then
       local elytron_https_connector=$(create_elytron_https_connector "https" "https" "LocalhostSslContext" "true")
-      sed -i "s|<!-- ##HTTPS_CONNECTOR## -->|${elytron_https_connector}|" $CONFIG_FILE
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##HTTPS_CONNECTOR## -->${AUS}${elytron_https_connector}${AUS}" $CONFIG_FILE
+      # EOF CIAM-1394 correction
     elif [ "${elytron_https_connector_conf_mode}" = "cli" ]; then
       create_elytron_https_connector_cli "https" "https" "LocalhostSslContext" "true"
     fi
@@ -381,8 +391,10 @@ configure_elytron_integration() {
           </security-realms>\n\
     </elytron-integration>"
 
-    sed -i "s|<!-- ##ELYTRON_INTEGRATION## -->|${elytron_integration}|" $CONFIG_FILE
-    sed -i "s|<!-- ##INTEGRATION_ELYTRON_REALM## -->|${elytron_realm}<!-- ##INTEGRATION_ELYTRON_REALM## -->|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##ELYTRON_INTEGRATION## -->${AUS}${elytron_integration}${AUS}" $CONFIG_FILE
+    sed -i "s${AUS}<!-- ##INTEGRATION_ELYTRON_REALM## -->${AUS}${elytron_realm}<!-- ##INTEGRATION_ELYTRON_REALM## -->${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
   elif [ "${configureMode}" = "cli" ]; then
 
      cat << EOF >> ${CLI_SCRIPT_FILE}
@@ -403,7 +415,9 @@ configure_elytron_security_domain() {
                       <realm name=\"${SECDOMAIN_NAME}\"/>\n\
                   </security-domain>"
 
-    sed -i "s|<!-- ##ELYTRON_SECURITY_DOMAIN## -->|${elytron_security_domain}<!-- ##ELYTRON_SECURITY_DOMAIN## -->|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##ELYTRON_SECURITY_DOMAIN## -->${AUS}${elytron_security_domain}<!-- ##ELYTRON_SECURITY_DOMAIN## -->${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
 
   elif [ "${configureMode}" = "cli" ]; then
 
@@ -428,7 +442,9 @@ configure_http_authentication_factory() {
                       </mechanism-configuration>\n\
                   </http-authentication-factory>"
 
-      sed -i "s|<!-- ##HTTP_AUTHENTICATION_FACTORY## -->|${http_authentication_factory}<!-- ##HTTP_AUTHENTICATION_FACTORY## -->|" $CONFIG_FILE
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##HTTP_AUTHENTICATION_FACTORY## -->${AUS}${http_authentication_factory}<!-- ##HTTP_AUTHENTICATION_FACTORY## -->${AUS}" $CONFIG_FILE
+      # EOF CIAM-1394 correction
 
   elif [ "${configureMode}" = "cli" ]; then
 
@@ -450,8 +466,10 @@ configure_http_application_security_domains() {
                 <!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->\
             </application-security-domains>"
 
-    sed -i "s|<!-- ##HTTP_APPLICATION_SECURITY_DOMAINS## -->|${http_application_security_domains}|" $CONFIG_FILE
-    sed -i "s|<!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->|${application_security_domain}<!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##HTTP_APPLICATION_SECURITY_DOMAINS## -->${AUS}${http_application_security_domains}${AUS}" $CONFIG_FILE
+    sed -i "s${AUS}<!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->${AUS}${application_security_domain}<!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
 
   elif [ "${configureMode}" = "cli" ]; then
 
@@ -473,8 +491,10 @@ configure_ejb_application_security_domains() {
                 <!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->\
             </application-security-domains>"
 
-    sed -i "s|<!-- ##EJB_APPLICATION_SECURITY_DOMAINS## -->|${ejb_application_security_domains}|" $CONFIG_FILE
-    sed -i "s|<!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->|${application_security_domain}<!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##EJB_APPLICATION_SECURITY_DOMAINS## -->${AUS}${ejb_application_security_domains}${AUS}" $CONFIG_FILE
+    sed -i "s${AUS}<!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->${AUS}${application_security_domain}<!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
 
   elif [ "${configureMode}" = "cli" ]; then
 

--- a/modules/eap/setup/eap/modules/added/launch/ha.sh
+++ b/modules/eap/setup/eap/modules/added/launch/ha.sh
@@ -323,7 +323,9 @@ configure_ha() {
   fi
 
   if [ "${CONF_AUTH_MODE}" = "xml" ]; then
-    sed -i "s|<!-- ##JGROUPS_AUTH## -->|${JGROUPS_AUTH}|g" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##JGROUPS_AUTH## -->${AUS}${JGROUPS_AUTH}${AUS}g" $CONFIG_FILE
+    # EOF CIAM-1394 correction
   elif [ "${CONF_AUTH_MODE}" = "cli" ]; then
     echo "${JGROUPS_AUTH}" >> ${CLI_SCRIPT_FILE};
   fi
@@ -331,7 +333,9 @@ configure_ha() {
   log_info "Configuring JGroups discovery protocol to ${ping_protocol}"
 
   if [ "${CONF_PING_MODE}" = "xml" ]; then
-    sed -i "s|<!-- ##JGROUPS_PING_PROTOCOL## -->|${ping_protocol_element}|g" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##JGROUPS_PING_PROTOCOL## -->${AUS}${ping_protocol_element}${AUS}g" $CONFIG_FILE
+    # EOF CIAM-1394 correction
   elif [ "${CONF_PING_MODE}" = "cli" ]; then
     echo "${ping_protocol_element}" >> ${CLI_SCRIPT_FILE};
   fi

--- a/modules/eap/setup/eap/modules/added/launch/jgroups.sh
+++ b/modules/eap/setup/eap/modules/added/launch/jgroups.sh
@@ -387,13 +387,17 @@ configure_jgroups_encryption() {
   esac
 
   if [ "${key_store_conf_mode}" = "xml" ]; then
-    sed -i "s|<!-- ##ELYTRON_KEY_STORE## -->|${key_store}<!-- ##ELYTRON_KEY_STORE## -->|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##ELYTRON_KEY_STORE## -->${AUS}${key_store}<!-- ##ELYTRON_KEY_STORE## -->${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
   elif [ "${key_store_conf_mode}" = "cli" ]; then
     echo "${key_store}" >> ${CLI_SCRIPT_FILE}
   fi
 
   if [ "${encrypt_conf_mode}" = "xml" ]; then
-    sed -i "s|<!-- ##JGROUPS_ENCRYPT## -->|${jgroups_encrypt}|g" "$CONFIG_FILE"
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##JGROUPS_ENCRYPT## -->${AUS}${jgroups_encrypt}${AUS}g" "$CONFIG_FILE"
+    # EOF CIAM-1394 correction
   elif [ "${encrypt_conf_mode}" = "cli" ]; then
     echo "${jgroups_encrypt}" >> ${CLI_SCRIPT_FILE}
   fi

--- a/modules/eap/setup/eap/modules/added/launch/login-modules-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/login-modules-common.sh
@@ -24,7 +24,9 @@ function configure_login_modules() {
         getConfigurationMode "<!-- ##OTHER_LOGIN_MODULES## -->" "confMode"
 
         if [ "${confMode}" = "xml" ]; then
-          sed -i "s|<!-- ##OTHER_LOGIN_MODULES## -->|${login_modules}<!-- ##OTHER_LOGIN_MODULES## -->|" "$CONFIG_FILE"
+          # CIAM-1394 correction
+          sed -i "s${AUS}<!-- ##OTHER_LOGIN_MODULES## -->${AUS}${login_modules}<!-- ##OTHER_LOGIN_MODULES## -->${AUS}" "$CONFIG_FILE"
+          # EOF CIAM-1394 correction
         elif [ "${confMode}" = "cli" ]; then
           configure_login_module_cli "${login_module_code}" "${login_module_flag}" "${login_module_module}"
         fi

--- a/modules/eap/setup/eap/modules/added/launch/management-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/management-common.sh
@@ -15,7 +15,9 @@ function add_management_interface_realm() {
 
     if [ "${mode}" = "xml" ]; then
       mgmt_iface_replace_str=" security-realm=\"$mgmt_iface_realm\">"
-      sed -i "s|><!-- ##MGMT_IFACE_REALM## -->|${mgmt_iface_replace_str}|" "$CONFIG_FILE"
+      # CIAM-1394 correction
+      sed -i "s${AUS}><!-- ##MGMT_IFACE_REALM## -->${AUS}${mgmt_iface_replace_str}${AUS}" "$CONFIG_FILE"
+      # EOF CIAM-1394 correction
     elif [ "${mode}" = "cli" ]; then
       cat << EOF >> "${CLI_SCRIPT_FILE}"
       if (outcome != success) of /core-service=management/management-interface=http-interface:read-resource

--- a/modules/eap/setup/eap/modules/added/launch/ports.sh
+++ b/modules/eap/setup/eap/modules/added/launch/ports.sh
@@ -20,7 +20,9 @@ function configure_port_offset() {
     getConfigurationMode "port-offset=\"0\"" "mode"
 
     if [ "${mode}" = "xml" ]; then
-      sed -i "s|port-offset=\"0\"|port-offset=\"${PORT_OFFSET}\"|g" "$CONFIG_FILE"
+      # CIAM-1394 correction
+      sed -i "s${AUS}port-offset=\"0\"${AUS}port-offset=\"${PORT_OFFSET}\"${AUS}g" "$CONFIG_FILE"
+      # EOF CIAM-1394 correction
     elif [ "${mode}" = "cli" ]; then
 
       local cli="

--- a/modules/eap/setup/eap/modules/added/launch/resource-adapters-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/resource-adapters-common.sh
@@ -83,9 +83,13 @@ function inject_resource_adapters_common() {
   done
 
   if [ -n "${resource_adapters}" ]; then
-    resource_adapters=$(echo "${resource_adapters}" | sed -e "s/localhost/${hostname}/g")
+    # CIAM-1394 correction
+    resource_adapters=$(echo "${resource_adapters}" | sed -e "s${AUS}localhost${AUS}${hostname}${AUS}g")
+    # EOF CIAM-1394 correction
     if [ "${mode}" = "xml" ]; then
-      sed -i "s|<!-- ##RESOURCE_ADAPTERS## -->|${resource_adapters}<!-- ##RESOURCE_ADAPTERS## -->|" $CONFIG_FILE
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##RESOURCE_ADAPTERS## -->${AUS}${resource_adapters}<!-- ##RESOURCE_ADAPTERS## -->${AUS}" $CONFIG_FILE
+      # EOF CIAM-1394 correction
     elif [ "${mode}" = "cli" ]; then
       echo "${resource_adapters}" >> ${CLI_SCRIPT_FILE}
     fi
@@ -204,7 +208,9 @@ function add_connection_definitions() {
 
       if [ -n "$ra_props" ]; then
         for ra_prop in $(echo $ra_props); do
-          prop_name=$(echo "${ra_prop}" | sed -e "s/${ra_prefix}_PROPERTY_//g")
+          # CIAM-1394 correction
+          prop_name=$(echo "${ra_prop}" | sed -e "s${AUS}${ra_prefix}_PROPERTY_${AUS}${AUS}g")
+          # EOF CIAM-1394 correction
           prop_val=$(find_env $ra_prop)
 
           resource_adapter="${resource_adapter}<config-property name=\"${prop_name}\">${prop_val}</config-property>"
@@ -319,7 +325,9 @@ function add_connection_definitions() {
 
       if [ -n "$ra_props" ]; then
         for ra_prop in $(echo $ra_props); do
-          prop_name=$(echo "${ra_prop}" | sed -e "s/${ra_prefix}_PROPERTY_//g")
+          # CIAM-1394 correction
+          prop_name=$(echo "${ra_prop}" | sed -e "s${AUS}${ra_prefix}_PROPERTY_${AUS}${AUS}g")
+          # EOF CIAM-1394 correction
           prop_val=$(find_env $ra_prop)
           resource_adapter="${resource_adapter}
             ${conn_def_addr}/config-properties=${prop_name}:add(value=\"${prop_val}\")

--- a/modules/eap/setup/eap/modules/added/launch/security-domains.sh
+++ b/modules/eap/setup/eap/modules/added/launch/security-domains.sh
@@ -55,7 +55,9 @@ configure_security_domains() {
             </authentication>\n\
         </security-domain>\n"
 
-      sed -i "s|<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->|${domains}<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->|" "$CONFIG_FILE"
+      # CIAM-1394 correction
+      sed -i "s${AUS}<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->${AUS}${domains}<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->${AUS}" "$CONFIG_FILE"
+      # EOF CIAM-1394 correction
 
     elif [ "${confMode}" = "cli" ]; then
 

--- a/modules/eap/setup/eap/modules/added/launch/tx-datasource.sh
+++ b/modules/eap/setup/eap/modules/added/launch/tx-datasource.sh
@@ -70,7 +70,9 @@ function inject_jdbc_store() {
               <communication table-prefix=\"${prefix}\"/>\\
               <state table-prefix=\"${prefix}\"/>\\
           </jdbc-store>"
-    sed -i "s|<!-- ##JDBC_STORE## -->|${jdbcStore}|" $CONFIG_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##JDBC_STORE## -->${AUS}${jdbcStore}${AUS}" $CONFIG_FILE
+    # EOF CIAM-1394 correction
   elif [ "${dsConfMode}" = "cli" ]; then
     local subsystem_addr="/subsystem=transactions"
     # Since we have variables indicating that we should use a JDBC store in the Tx subsystem, we
@@ -208,7 +210,9 @@ function inject_tx_datasource() {
       if [ "${dsConfMode}" = "xml" ]; then
         # Only do this replacement if we are replacing an xml marker
         datasource_adjusted="$(echo ${datasource} | sed ':a;N;$!ba;s|\n|\\n|g')"
-        sed -i "s|<!-- ##DATASOURCES## -->|${datasource_adjusted}<!-- ##DATASOURCES## -->|" $CONFIG_FILE
+        # CIAM-1394 correction
+        sed -i "s${AUS}<!-- ##DATASOURCES## -->${AUS}${datasource_adjusted}<!-- ##DATASOURCES## -->${AUS}" $CONFIG_FILE
+        # EOF CIAM-1394 correction
       elif [ "${dsConfMode}" = "cli" ]; then
         # If using cli, return the raw string, preserving line breaks
         echo "${datasource}" >> "${CLI_SCRIPT_FILE}"

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/eap/galleon/patching.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/eap/galleon/patching.sh
@@ -4,7 +4,9 @@ mavenRepo="$1"
 if [ -f "$mavenRepo/patches.xml" ]; then
   echo "The maven repository has been patched, setting patches in galleon feature-pack."
   patches=`cat "$mavenRepo/patches.xml" | sed ':a;N;$!ba;s/\n//g'`
-  sed -i "s|<!-- ##PATCHES## -->|$patches|" "${GALLEON_FP_PATH}/wildfly-user-feature-pack-build.xml"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ##PATCHES## -->${AUS}$patches${AUS}" "${GALLEON_FP_PATH}/wildfly-user-feature-pack-build.xml"
+  # EOF CIAM-1394 correction
   echo "wildfly-user-feature-pack-build.xml content:"
   cat "${GALLEON_FP_PATH}/wildfly-user-feature-pack-build.xml"
 fi

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/maven.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/maven.sh
@@ -151,7 +151,9 @@ function _add_maven_proxy() {
   xml="$xml\
        </proxy>"
     local sub="<!-- ### configured http proxy ### -->"
-    sed -i "s^${sub}^${xml}^" "$settings"
+    # CIAM-1394 correction
+    sed -i "s${AUS}${sub}${AUS}${xml}${AUS}" "$settings"
+    # EOF CIAM-1394 correction
   fi
 }
 
@@ -231,7 +233,9 @@ function _add_maven_mirror() {
     </mirror>\n\
     <!-- ### configured mirrors ### -->"
 
-  sed -i "s|<!-- ### configured mirrors ### -->|$xml|" "${settings}"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ### configured mirrors ### -->${AUS}$xml${AUS}" "${settings}"
+  # EOF CIAM-1394 correction
 
 }
 
@@ -241,7 +245,9 @@ function add_maven_repos() {
   # set the local repository
   local local_repo_xml="\n\
   <localRepository>${MAVEN_LOCAL_REPO}</localRepository>"
-  sed -i "s|<!-- ### configured local repository ### -->|${local_repo_xml}|" "${settings}"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ### configured local repository ### -->${AUS}${local_repo_xml}${AUS}" "${settings}"
+  # EOF CIAM-1394 correction
 
   # single remote repository scenario: respect fully qualified url if specified, otherwise find and use service
   local single_repo_url="${MAVEN_REPO_URL}"
@@ -344,13 +350,17 @@ function _add_maven_repo_profile() {
     </repositories>\n\
   </profile>\n\
   <!-- ### configured profiles ### -->"
-  sed -i "s|<!-- ### configured profiles ### -->|${xml}|" "${settings}"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ### configured profiles ### -->${AUS}${xml}${AUS}" "${settings}"
+  # EOF CIAM-1394 correction
 
   # activate the configured profile
   xml="\n\
     <activeProfile>${profile_id}</activeProfile>\n\
     <!-- ### active profiles ### -->"
-  sed -i "s|<!-- ### active profiles ### -->|${xml}|" "${settings}"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ### active profiles ### -->${AUS}${xml}${AUS}" "${settings}"
+  # EOF CIAM-1394 correction
 }
 
 # private
@@ -390,7 +400,9 @@ function _add_maven_repo_server() {
   xml="${xml}\n\
     </server>\n\
     <!-- ### configured servers ### -->"
-  sed -i "s|<!-- ### configured servers ### -->|${xml}|" "${settings}"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ### configured servers ### -->${AUS}${xml}${AUS}" "${settings}"
+  # EOF CIAM-1394 correction
 }
 
 # private

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
@@ -12,7 +12,9 @@ function galleon_patch_generic_config() {
        fi
      done
      if [ -n "$layers" ]; then
-       sed -i "s|<!-- ##GALLEON_LAYERS## -->|${layers}|" $GALLEON_GENERIC_LAYERS_DEFINITION/config.xml
+       # CIAM-1394 correction
+       sed -i "s${AUS}<!-- ##GALLEON_LAYERS## -->${AUS}${layers}${AUS}" $GALLEON_GENERIC_LAYERS_DEFINITION/config.xml
+       # EOF CIAM-1394 correction
      fi
    fi
    if [ -n "$GALLEON_PROVISION_FEATURE_PACKS" ]; then
@@ -22,7 +24,9 @@ function galleon_patch_generic_config() {
        featurepacks="$featurepacks<location>$fp</location></feature-pack>"
      done
      if [ -n "$featurepacks" ]; then
-       sed -i "s|<!-- ##GALLEON_FEATURE_PACKS## -->|${featurepacks}|" $GALLEON_GENERIC_LAYERS_DEFINITION/pom.xml
+       # CIAM-1394 correction
+       sed -i "s${AUS}<!-- ##GALLEON_FEATURE_PACKS## -->${AUS}${featurepacks}${AUS}" $GALLEON_GENERIC_LAYERS_DEFINITION/pom.xml
+       # EOF CIAM-1394 correction
      fi
    fi
 }

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
@@ -104,7 +104,9 @@ function configure_drivers(){
 
       if [ -n "$drivers" ] ; then
         if [ "${configMode}" = "xml" ]; then
-          sed -i "s|<!-- ##DRIVERS## -->|${drivers}<!-- ##DRIVERS## -->|" $CONFIG_FILE
+          # CIAM-1394 correction
+          sed -i "s${AUS}<!-- ##DRIVERS## -->${AUS}${drivers}<!-- ##DRIVERS## -->${AUS}" $CONFIG_FILE
+          # EOF CIAM-1394 correction
         elif [ "${configMode}" = "cli" ]; then
           if [ "${CONFIG_ADJUSTMENT_MODE,,}" = "cli" ]; then
             # CLI execution to add current driver(s)

--- a/modules/eap/setup/eap/modules/configure.sh
+++ b/modules/eap/setup/eap/modules/configure.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 ### Start of: 'jboss-eap-7-image/modules/eap-74-galleon/7.4.0' module
 # Configure module
 
@@ -387,7 +391,9 @@ popd
 cp $HOME/.m2/settings.xml "$GALLEON_MAVEN_SETTINGS_XML"
 local_repo_xml="\n\
   <localRepository>${GALLEON_LOCAL_MAVEN_REPO}</localRepository>"
-sed -i "s|<!-- ### configured local repository ### -->|${local_repo_xml}|" "$GALLEON_MAVEN_SETTINGS_XML"
+# CIAM-1394 correction
+sed -i "s${AUS}<!-- ### configured local repository ### -->${AUS}${local_repo_xml}${AUS}" "$GALLEON_MAVEN_SETTINGS_XML"
+# EOF CIAM-1394 correction
 chown jboss:root $GALLEON_MAVEN_SETTINGS_XML
 chmod ug+rwX $GALLEON_MAVEN_SETTINGS_XML
 
@@ -396,7 +402,9 @@ if [ ! -f "$GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML" ]; then
   cp $HOME/.m2/settings.xml "$GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML"
   local_repo_xml="\n\
     <localRepository>${TMP_GALLEON_LOCAL_MAVEN_REPO}</localRepository>"
-  sed -i "s|<!-- ### configured local repository ### -->|${local_repo_xml}|" "$GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML"
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ### configured local repository ### -->${AUS}${local_repo_xml}${AUS}" "$GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML"
+  # EOF CIAM-1394 correction
   chown jboss:root $GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML
   chmod ug+rwX $GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML
 fi
@@ -436,7 +444,9 @@ galleon_profile="<profile>\n\
       </pluginRepositories>\n\
     </profile>\n\
 "
-sed -i "s|<\!-- ### configured profiles ### -->|$galleon_profile <\!-- ### configured profiles ### -->|" $HOME/.m2/settings.xml
+# CIAM-1394 correction
+sed -i "s${AUS}<\!-- ### configured profiles ### -->${AUS}$galleon_profile <\!-- ### configured profiles ### -->${AUS}" $HOME/.m2/settings.xml
+# EOF CIAM-1394 correction
 ### End of: 'wildfly-cekit-modules/jboss/container/wildfly/s2i/bash' module
 
 ### Start of: 'jboss-eap-modules/jboss/container/eap/s2i/galleon' module
@@ -1088,8 +1098,10 @@ EOF
 # Escape all newlines in the value of 'keycloakModelInfinispanDependency'
 keycloakModelInfinispanDependency="${keycloakModelInfinispanDependency//$'\n'/\\n}"
 
+# CIAM-1394 correction
 # Actually append the new "org.keycloak.keycloak-model-infinispan" dependency line
-sed -i "s|${fourSpaces}</dependencies>|${keycloakModelInfinispanDependency}\n${fourSpaces}</dependencies>|" \
+sed -i "s${AUS}${fourSpaces}</dependencies>${AUS}${keycloakModelInfinispanDependency}\n${fourSpaces}</dependencies>${AUS}" \
     "${wildflyClusteringInfinispanSpiModuleXml}"
+# EOF CIAM-1394 correction
 
 ### CIAM-743 -- End of RH-SSO add-on

--- a/modules/eap/setup/eap/modules/dynamic_resources.sh
+++ b/modules/eap/setup/eap/modules/dynamic_resources.sh
@@ -42,10 +42,14 @@ adjust_java_heap_settings() {
     local initial_heap=$(echo "${java_options}" | grep -Eo "\-Xms[^ ]* ")
 
     if [ -n "$max_heap" ]; then
-        JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-Xmx[^ ]*/${max_heap} /")
+        # CIAM-1394 correction
+        JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s${AUS}-Xmx[^ ]*${AUS}${max_heap} ${AUS}")
+        # EOF CIAM-1394 correction
     fi
     if [ -n "$initial_heap" ]; then
-        JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-Xms[^ ]* /${initial_heap} /")
+        # CIAM-1394 correction
+        JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s${AUS}-Xms[^ ]* ${AUS}${initial_heap} ${AUS}")
+        # EOF CIAM-1394 correction
     fi
 }
 
@@ -78,7 +82,9 @@ adjust_java_options() {
     for option in $java_options; do
         if [[ ${option} == "-Xmx"* ]]; then
             if [[ "$options" == *"-Xmx"* ]]; then
-                options=$(echo $options | sed -e "s/-Xmx[^ ]*/${option}/")
+                # CIAM-1394 correction
+                options=$(echo $options | sed -e "s${AUS}-Xmx[^ ]*${AUS}${option}${AUS}")
+                # EOF CIAM-1394 correction
             else
                 options="${options} ${option}"
             fi
@@ -87,7 +93,9 @@ adjust_java_options() {
             fi
         elif [[ ${option} == "-Xms"* ]]; then
             if [[ "$options" == *"-Xms"* ]]; then
-                options=$(echo $options | sed -e "s/-Xms[^ ]*/${option}/")
+                # CIAM-1394 correction
+                options=$(echo $options | sed -e "s${AUS}-Xms[^ ]*${AUS}${option}${AUS}")
+                # EOF CIAM-1394 correction
             else
                 options="${options} ${option}"
             fi

--- a/modules/sso/config/launch/setup/75/added/launch/add-sso-realm.sh
+++ b/modules/sso/config/launch/setup/75/added/launch/add-sso-realm.sh
@@ -13,7 +13,9 @@ function configure() {
 
 function realm_import() {
   if [ -n "${SSO_REALM}" ]; then
-    sed -i "s|##REALM##|${SSO_REALM}|" "${IMPORT_REALM_FILE}"
+    # CIAM-1394 correction
+    sed -i "s${AUS}##REALM##${AUS}${SSO_REALM}${AUS}" "${IMPORT_REALM_FILE}"
+    # EOF CIAM-1394 correction
     if [ -n "${SSO_SERVICE_USERNAME}" ]; then
       if [ -n "${SSO_SERVICE_PASSWORD}" ]; then
         "${JBOSS_HOME}/bin/add-user-keycloak.sh" -r "${SSO_REALM}" -u "${SSO_SERVICE_USERNAME}" -p "${SSO_SERVICE_PASSWORD}" --roles realm-management/realm-admin

--- a/modules/sso/config/launch/setup/75/added/launch/datasource.sh
+++ b/modules/sso/config/launch/setup/75/added/launch/datasource.sh
@@ -109,16 +109,18 @@ function refresh_interval() {
 
 function inject_default_job_repositories() {
   defaultjobrepo="     <default-job-repository name=\"in-memory\"/>"
-
-  sed -i "s|<!-- ##DEFAULT_JOB_REPOSITORY## -->|${defaultjobrepo%$'\n'}|g" $CONFIG_FILE
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ##DEFAULT_JOB_REPOSITORY## -->${AUS}${defaultjobrepo%$'\n'}${AUS}g" $CONFIG_FILE
+  # EOF CIAM-1394 correction
 }
 
 # Arguments:
 # $1 - default job repository name
 function inject_default_job_repository() {
   defaultjobrepo="     <default-job-repository name=\"${1}\"/>"
-
-  sed -i "s|<!-- ##DEFAULT_JOB_REPOSITORY## -->|${defaultjobrepo%$'\n'}|" $CONFIG_FILE
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ##DEFAULT_JOB_REPOSITORY## -->${AUS}${defaultjobrepo%$'\n'}${AUS}" $CONFIG_FILE
+  # EOF CIAM-1394 correction
 }
 
 function inject_job_repository() {
@@ -126,6 +128,7 @@ function inject_job_repository() {
       <jdbc data-source=\"${1}\"/>\
     </job-repository>\
     <!-- ##JOB_REPOSITORY## -->"
-
-  sed -i "s|<!-- ##JOB_REPOSITORY## -->|${jobrepo%$'\n'}|" $CONFIG_FILE
+  # CIAM-1394 correction
+  sed -i "s${AUS}<!-- ##JOB_REPOSITORY## -->${AUS}${jobrepo%$'\n'}${AUS}" $CONFIG_FILE
+  # EOF CIAM-1394 correction
 }

--- a/modules/sso/config/launch/setup/75/added/launch/keycloak-spi.sh
+++ b/modules/sso/config/launch/setup/75/added/launch/keycloak-spi.sh
@@ -22,7 +22,9 @@ function add_truststore() {
 
     local truststore="<spi name=\"truststore\"><provider name=\"file\" enabled=\"true\"><properties><property name=\"file\" value=\"${SSO_TRUSTSTORE_DIR}/${SSO_TRUSTSTORE}\"/><property name=\"password\" value=\"${SSO_TRUSTSTORE_PASSWORD}\"/><property name=\"hostname-verification-policy\" value=\"WILDCARD\"/><property name=\"disabled\" value=\"false\"/></properties></provider></spi>"
 
-    sed -i "s|<!-- ##SSO_TRUSTSTORE## -->|${truststore}|" "${CONFIG_FILE}"
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##SSO_TRUSTSTORE## -->${AUS}${truststore}${AUS}" "${CONFIG_FILE}"
+    # EOF CIAM-1394 correction
 
   fi
 }
@@ -32,7 +34,9 @@ function add_vault() {
   if [ -n "$SSO_VAULT_DIR" ]; then
 
     local vault="<spi name=\"vault\"><default-provider>files-plaintext</default-provider><provider name=\"files-plaintext\" enabled=\"true\"><properties><property name=\"dir\" value=\"${SSO_VAULT_DIR}\"/></properties></provider></spi>"
-    sed -i "s|<!-- ##SSO_VAULT_CONFIG## -->|${vault}|" "${CONFIG_FILE}"
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##SSO_VAULT_CONFIG## -->${AUS}${vault}${AUS}" "${CONFIG_FILE}"
+    # EOF CIAM-1394 correction
   fi
 }
 
@@ -47,7 +51,9 @@ function set_server_hostname_spi_to_default() {
     fi
     local -r hostname_spi="<spi name=\"hostname\"><default-provider>default</default-provider><provider name=\"default\" enabled=\"true\"><properties>${properties}</properties></provider></spi>"
 
-    sed -i "s|<!-- ##SSO_SERVER_HOSTNAME_SPI## -->|${hostname_spi}|" "${CONFIG_FILE}"
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##SSO_SERVER_HOSTNAME_SPI## -->${AUS}${hostname_spi}${AUS}" "${CONFIG_FILE}"
+    # EOF CIAM-1394 correction
 
   fi
 }
@@ -65,7 +71,9 @@ function set_server_hostname_spi_to_fixed() {
     local -r requested_hostname="$1"
     local -r hostname_spi="<spi name=\"hostname\"><default-provider>fixed</default-provider><provider name=\"fixed\" enabled=\"true\"><properties><property name=\"hostname\" value=\"${requested_hostname}\"/><property name=\"httpPort\" value=\"-1\"/><property name=\"httpsPort\" value=\"-1\"/><property name=\"alwaysHttps\" value=\"false\"/></properties></provider></spi>"
 
-    sed -i "s|<!-- ##SSO_SERVER_HOSTNAME_SPI## -->|${hostname_spi}|" "${CONFIG_FILE}"
+    # CIAM-1394 correction
+    sed -i "s${AUS}<!-- ##SSO_SERVER_HOSTNAME_SPI## -->${AUS}${hostname_spi}${AUS}" "${CONFIG_FILE}"
+    # EOF CIAM-1394 correction
 
   fi
 }

--- a/modules/sso/config/launch/setup/75/added/openshift-launch.sh
+++ b/modules/sso/config/launch/setup/75/added/openshift-launch.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Openshift EAP launch script
 
+# Import RH-SSO global variables & functions to container run-time
+source ${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh
+# Other imports
 source ${JBOSS_HOME}/bin/launch/openshift-common.sh
 source $JBOSS_HOME/bin/launch/logging.sh
 

--- a/modules/sso/config/launch/setup/75/configure.sh
+++ b/modules/sso/config/launch/setup/75/configure.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
-
 set -e
+
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
 
 SCRIPT_DIR=$(dirname "$0")
 ADDED_DIR=${SCRIPT_DIR}/added

--- a/modules/sso/db/drivers/configure.sh
+++ b/modules/sso/db/drivers/configure.sh
@@ -2,6 +2,10 @@
 # Link DB drivers, provided by RPM packages, into the "openshift" layer
 set -e
 
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 

--- a/modules/sso/keycloak/openshift/clients/install
+++ b/modules/sso/keycloak/openshift/clients/install
@@ -2,6 +2,10 @@
 # Add Red Hat Single Sign-On client adapters
 set -eu
 
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 #
 # Main shell script body
 #

--- a/modules/sso/rcfile/configure.sh
+++ b/modules/sso/rcfile/configure.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Configure module
+SCRIPT_DIR="$(dirname "$0")"
+# Final destination of the rcfile script within the container image
+readonly RC_SCRIPT_DEST="${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
+# Create empty JBOSS_HOME/bin/launch directory needed to install module content
+mkdir -p "${JBOSS_HOME}/bin/launch"
+
+# Install & configure the rcfile definitions file
+cp "${SCRIPT_DIR}/sso-rcfile-definitions.sh" "${RC_SCRIPT_DEST}"
+# The 'jboss' user doesn't exist yet. Use his future numeric UID instead
+chown 185:root "${RC_SCRIPT_DEST}"
+chmod ug+rwX "${RC_SCRIPT_DEST}"
+
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"

--- a/modules/sso/rcfile/module.yaml
+++ b/modules/sso/rcfile/module.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+name: sso.rcfile
+version: '1.0'
+description: >
+  Defines RH-SSO global variables & functions required by subsequent image modules.
+envs:
+- name: "JBOSS_HOME"
+  value: "/opt/eap"
+execute:
+- script: configure.sh

--- a/modules/sso/rcfile/sso-rcfile-definitions.sh
+++ b/modules/sso/rcfile/sso-rcfile-definitions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+set -e
+# NOTE: This script intentionally doesn't include the Bash 'set -u' option
+#       (the set builtin option to treat unset variables as errors) on the
+#       previous line, since it's included in the RH-SSO container runtime
+#       phase too, and there it could cause unsolicited container aborts when
+#       checking if some optional runtime env var was specified or not
+
+
+### RH-SSO global variables & functions
+
+# CIAM-1394 Use a non-printable character - ASCII 31 (octal 037) unit
+# separator character as the sed substitute (s) command delimiter for each
+# existing call of "sed -i" and "sed -e" across the various container image
+# modules, where either the regexp or the replacement value is dynamically
+# generated (IOW it's not a fixed string) and it's based on / derived from
+# the value of some environment variable.
+#
+# Do this to avoid clash of the sed substitute command delimiter with some
+# special character specified in env var value (e.g. in password), leading to:
+#
+# * sed: -e expression #1, char <CHAR_POS>: unterminated `s' command
+# * sed: -e expression #1, char <CHAR_POS>: unknown option to 's'
+#
+# type of errors
+# shellcheck disable=SC2034
+export readonly AUS=$'\037'

--- a/modules/sso/sso-cli-extensions/configure.sh
+++ b/modules/sso/sso-cli-extensions/configure.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -e
+
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
 
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added

--- a/modules/sso/sso-jdk/11/configure.sh
+++ b/modules/sso/sso-jdk/11/configure.sh
@@ -2,6 +2,10 @@
 # Configure module
 set -e
 
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
@@ -33,7 +37,9 @@ fi
 # Update securerandom.source for quicker starts (must be done after removing jdk 11, or it will hit the wrong files)
 SECURERANDOM=securerandom.source
 if grep -q "^$SECURERANDOM=.*" $JAVA_SECURITY_FILE; then
-    sed -i "s|^$SECURERANDOM=.*|$SECURERANDOM=file:/dev/urandom|" $JAVA_SECURITY_FILE
+    # CIAM-1394 correction
+    sed -i "s${AUS}^$SECURERANDOM=.*${AUS}$SECURERANDOM=file:/dev/urandom${AUS}" $JAVA_SECURITY_FILE
+    # EOF CIAM-1394 correction
 else
     echo $SECURERANDOM=file:/dev/urandom >> $JAVA_SECURITY_FILE
 fi

--- a/modules/sso/sso-pre-launch-checks/configure.sh
+++ b/modules/sso/sso-pre-launch-checks/configure.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-
 set -e
+
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
 
 SCRIPT_DIR=$(dirname "$0")
 ADDED_DIR=${SCRIPT_DIR}/added

--- a/modules/sso/sso-rm-openjdk/11/configure.sh
+++ b/modules/sso/sso-rm-openjdk/11/configure.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
-set -u
-set -e
+set -eu
+
+# Import RH-SSO global variables & functions to image build-time
+# shellcheck disable=SC1091
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
 
 ## Work around OpenJDK being installed as dependency. https://bugzilla.redhat.com/show_bug.cgi?id=1762827 and similar
 if rpm -q ibm-semeru-open-11-jdk || rpm -q java-11-openj9-devel; then
@@ -12,4 +15,3 @@ if rpm -q ibm-semeru-open-11-jdk || rpm -q java-11-openj9-devel; then
         fi
     done
 fi
-


### PR DESCRIPTION
    [CIAM-1394] Use a non-printable character -- ASCII unit separator
    as the sed substitute command delimiter for each existing call of
    "sed -i" and "sed -e" across the various modules, where either the
    regexp or replacement value is dynamically generated (IOW it's not
    a fixed string) and it's based / derived from the value of some
    environment variable
    
    This should prevent "sed: unterminated 's' command" and / or
    "sed: -e expression #1, char 702: unknown option to 's'" kind of
    happening when sed delimiter characters clashes with the same
    character being present in the value of some environment variable
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<hr/>

This is ready for review.
