### PR TITLE
[CIAM-1269] [SSOSUP-84] When starting the RH-SSO container, try to load the required boot dependencies from the local Galleon repository

### DIFF
--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/jboss-settings.xml
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/jboss-settings.xml
@@ -277,14 +277,16 @@
 
   </profiles>
   <activeProfiles>
-    <activeProfile>securecentral</activeProfile>
-    <!-- Start of RH-SSO add-on:
-         =======================
-         Explicitly activate the 'jboss-eap-repository' since at the very least the 'earlyaccess' repo is
-         required for the 'org.aesh:aesh-extensions:1.8.0.redhat-00001' artifact to be resolved properly.
+    <!-- CIAM-535 / KEYCLOAK-18574 correction
+      ~
+      ~  Explicitly activate the 'jboss-eap-repository' since at the very least
+      ~  the 'earlyaccess' repo is required to download the Galleon dependencies
+      ~  in the case these dependencies weren't published to external 3rd party
+      ~  Maven repositories yet
     -->
     <activeProfile>jboss-eap-repository</activeProfile>
-    <!-- End of RH-SSO add-on -->
+    <!-- EOF CIAM-535 / KEYCLOAK-18574 correction -->
+    <activeProfile>securecentral</activeProfile>
     <!-- ### active profiles ### -->
   </activeProfiles>
 </settings>

--- a/modules/eap/setup/eap/modules/configure.sh
+++ b/modules/eap/setup/eap/modules/configure.sh
@@ -383,6 +383,33 @@ pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
 
+# CIAM-1269 / SSOSUP-84 correction
+#
+# Since there can be only one <localRepository> element in the currently used
+# Maven settings.xml file, if the user requested custom Maven local repository
+# location via optional MAVEN_REPO_LOCAL or MAVEN_LOCAL_REPO image environment
+# variables, use that directory location for Galleon local repository too.
+# Otherwise set it to the default GALLEON_LOCAL_MAVEN_REPO environment variable
+# value, which is always set
+#
+GALLEON_LOCAL_MAVEN_REPO="${MAVEN_LOCAL_REPO:-${MAVEN_REPO_LOCAL:-${GALLEON_LOCAL_MAVEN_REPO}}}"
+local_repo_xml="\n\
+  <localRepository>${GALLEON_LOCAL_MAVEN_REPO}</localRepository>"
+
+# Similarly, if the user requested custom location of the user settings.xml
+# file via optional MAVEN_SETTINGS_XML image environment variable, use that
+# location instead of the default "${HOME}/.m2/settings.xml" one
+settings_xml="${MAVEN_SETTINGS_XML:-${HOME}/.m2/settings.xml}"
+
+# Finally set the <localRepository> element in settings.xml to point to chosen
+# directory to:
+# 1) Prevent needed artifact downloads by each container startup in online mode
+# 2) Make the previously downloaded artifacts available at container startup in
+#    offline mode too
+#
+sed -i "s|<!-- ### configured local repository ### -->|${local_repo_xml}|" "${settings_xml}"
+# EOF CIAM-1269 / SSOSUP-84 correction
+
 # Construct the settings in use by galleon at provisioning and startup.
 cp $HOME/.m2/settings.xml "$GALLEON_MAVEN_SETTINGS_XML"
 local_repo_xml="\n\
@@ -1020,6 +1047,11 @@ if [ ! -d "$GALLEON_LOCAL_MAVEN_REPO" ]; then
 fi
 
 rm -rf $TMP_GALLEON_LOCAL_MAVEN_REPO
+
+# CIAM-1269 / SSOSUP-84 correction
+# Make the 'jboss' user owner of the artifacts present in the local Galleon repository
+chown -R jboss:root "${GALLEON_LOCAL_MAVEN_REPO}"
+# EOF CIAM-1269 / SSOSUP-84 correction
 
 if [ ! -d $SERVER_DIR ]; then
   echo "Error, no server provisioned in $SERVER_DIR"


### PR DESCRIPTION
    [CIAM-1269] [SSOSUP-84] When starting the RH-SSO container, try to load the
    required boot dependencies from the local Galleon repository first to benefit
    from already downloaded artifacts
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

The following way of direct invocation of RH-SSO image can be used to reproduce the issue & verify the proposed fix (please note listing both the `SSO_ADMIN_USERNAME` and `SSO_ADMIN_PASSWORD` env vars is crucial in order the `keycloak.sh` script to need to load the `aesh-extensions` dependency):

```
$ docker run -it --network none -e SSO_ADMIN_USERNAME=admin -e SSO_ADMIN_PASSWORD=pwd registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5-6
```

With the latest `7.5-6` image the required `aesh-extensions` dependency fails to be loaded in offline mode:
```
$ docker run -it --network none -e SSO_ADMIN_USERNAME=admin -e SSO_ADMIN_PASSWORD=pwd registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5-6
WARN No password defined for JGroups cluster. AUTH protocol will be disabled. Please define JGROUPS_CLUSTER_PASSWORD.
WARN Environment variable OPENSHIFT_KUBE_PING_NAMESPACE undefined. Clustering will be unavailable. Please refer to the documentation for configuration.
INFO Configuring JGroups discovery protocol to kubernetes.KUBE_PING
INFO Using PicketBox SSL configuration.
INFO Configuring JGroups cluster traffic encryption protocol to SYM_ENCRYPT.
WARN Detected missing JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
Exception in thread "main" org.jboss.modules.ModuleLoadException: Error loading module from /opt/eap/modules/system/layers/base/org/aesh/main/module.xml
	at org.jboss.modules.xml.ModuleXmlParser.parseModuleXml(ModuleXmlParser.java:337)
	at org.jboss.modules.xml.ModuleXmlParser.parseModuleXml(ModuleXmlParser.java:293)
	at org.jboss.modules.xml.ModuleXmlParser.parseModuleXml(ModuleXmlParser.java:254)
	at org.jboss.modules.LocalModuleFinder.parseModuleXmlFile(LocalModuleFinder.java:250)
	at org.jboss.modules.LocalModuleFinder.lambda$findModule$1(LocalModuleFinder.java:195)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at org.jboss.modules.LocalModuleFinder.findModule(LocalModuleFinder.java:195)
	at org.jboss.modules.ModuleLoader.findModule0(ModuleLoader.java:700)
	at org.jboss.modules.ModuleLoader.findModule(ModuleLoader.java:693)
	at org.jboss.modules.ModuleLoader.loadModuleLocal(ModuleLoader.java:503)
	at org.jboss.modules.DelegatingModuleLoader.preloadModule(DelegatingModuleLoader.java:57)
	at org.jboss.modules.Module.addPaths(Module.java:1274)
	at org.jboss.modules.Module.link(Module.java:1644)
	at org.jboss.modules.Module.relinkIfNecessary(Module.java:1672)
	at org.jboss.modules.ModuleLoader.loadModule(ModuleLoader.java:303)
	at org.jboss.modules.Main.main(Main.java:371)
Caused by: org.jboss.modules.xml.XmlPullParserException: Failed to resolve artifact 'org.aesh:aesh-extensions:1.8.0.redhat-00001' (position: END_TAG seen ...    <artifact name="org.aesh:aesh-extensions:1.8.0.redhat-00001"/>... @29:71) 
	at org.jboss.modules.xml.ModuleXmlParser.parseArtifact(ModuleXmlParser.java:1050)
	at org.jboss.modules.xml.ModuleXmlParser.parseResources(ModuleXmlParser.java:937)
	at org.jboss.modules.xml.ModuleXmlParser.parseModuleContents(ModuleXmlParser.java:697)
	at org.jboss.modules.xml.ModuleXmlParser.parseDocument(ModuleXmlParser.java:469)
	at org.jboss.modules.xml.ModuleXmlParser.parseModuleXml(ModuleXmlParser.java:335)
	... 15 more
```

While with the updated image, the issue should disappear (the updated image should start normally in `offline` mode too).





Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
