### PR TITLE
[CIAM-1522] Execute delayedPostConfigure module as part of openshift-launch.sh script

### DIFF
--- a/modules/sso/config/launch/setup/75/added/openshift-launch.sh
+++ b/modules/sso/config/launch/setup/75/added/openshift-launch.sh
@@ -27,6 +27,10 @@ function runServer() {
   export NODE_NAME="${NODE_NAME:-node}-${count}"
 
   source $JBOSS_HOME/bin/launch/configure-modules.sh
+  # CIAM-1522 correction
+  # if a delayedpostconfigure.sh file exists call it, otherwise fallback on postconfigure.sh
+  executeModules delayedPostConfigure
+  # EOF CIAM-1522 correction
 
   log_info "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
 
@@ -62,6 +66,10 @@ if [ "${SPLIT_DATA^^}" = "TRUE" ]; then
   partitionPV "${DATA_DIR}" "${SPLIT_LOCK_TIMEOUT:-30}"
 else
   source $JBOSS_HOME/bin/launch/configure-modules.sh
+  # CIAM-1522 correction
+  # if a delayedpostconfigure.sh file exists call it, otherwise fallback on postconfigure.sh
+  executeModules delayedPostConfigure
+  # EOF CIAM-1522 correction
 
   log_info "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
 


### PR DESCRIPTION
    [CIAM-1522] Execute delayedPostConfigure module as part of openshift-launch.sh
    script (if a delayedpostconfigure.sh file exists call it, otherwise fallback on
    postconfigure.sh)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>


<hr/>

**Testing scenario / Steps to Reproduce:**

**Note:** See the respective JIRA comment for the information about the available candidate container image, containing the fix for this issue, and also demonstration of running the testing scenario below on it.

Listed below is a result of running the same scenario on / with the unfixed image:

- To demonstrate the bug on the unfixed image (used `registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5-6` version for testing) create a custom Dockerfile defining the `postconfigure.sh` script as part of container run:
```
$ cat Dockerfile 
# CIAM-1522 reproducer: '${JBOSS_HOME}/extensions/postconfigure.sh' is executed
# if and only if '${JBOSS_HOME}/extensions/delayedpostconfigure.sh' also exists
#
# But it should be executed regardless if 'delayedpostconfigure.sh' exists or
# not IOW the existence of '${JBOSS_HOME}/extensions/postconfigure.sh' itself
# is sufficient the post configure script to be executed
#
FROM registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5-6
ENV POST_CONFIGURE_SCRIPT_PATH "${JBOSS_HOME}/extensions/postconfigure.sh"
ENV FILE_TO_BE_CREATED "/tmp/file_created_with_postconfigure_sh_script"
RUN mkdir -p "$(dirname ${POST_CONFIGURE_SCRIPT_PATH})"
RUN printf '%s\n' \
           '#!/usr/bin/bash' \
           'set -eu' \
           '' \
           'echo Executing postconfigure.sh script...' \
           "touch ${FILE_TO_BE_CREATED}" \
           '' \
           > "${POST_CONFIGURE_SCRIPT_PATH}"
RUN chmod +x "${POST_CONFIGURE_SCRIPT_PATH}"
# Now build & run the image as usual. Wait for the image to be running, and
# confirm existence of '/tmp/file_created_with_postconfigure_sh_script' in
# the image. If the file exists, postconfigure.sh script was executed,
# otherwise not
```
- Rebuild the image
```
$ docker build .
Sending build context to Docker daemon  3.072kB
Step 1/6 : FROM registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5-6
 ---> ade02728448c
Step 2/6 : ENV POST_CONFIGURE_SCRIPT_PATH "${JBOSS_HOME}/extensions/postconfigure.sh"
 ---> Running in 25458a1b3786
Removing intermediate container 25458a1b3786
 ---> d9baaa88457d
Step 3/6 : ENV FILE_TO_BE_CREATED "/tmp/file_created_with_postconfigure_sh_script"
 ---> Running in 0b5a59424094
Removing intermediate container 0b5a59424094
 ---> 4049d6ad453d
Step 4/6 : RUN mkdir -p "$(dirname ${POST_CONFIGURE_SCRIPT_PATH})"
 ---> Running in 993703474cdb
Removing intermediate container 993703474cdb
 ---> 883bbc3ed857
Step 5/6 : RUN printf '%s\n'            '#!/usr/bin/bash'            'set -eu'            ''            'echo Executing postconfigure.sh script...'            "touch ${FILE_TO_BE_CREATED}"            ''            > "${POST_CONFIGURE_SCRIPT_PATH}"
 ---> Running in 87d4d7931881
Removing intermediate container 87d4d7931881
 ---> 0f7dbaa97071
Step 6/6 : RUN chmod +x "${POST_CONFIGURE_SCRIPT_PATH}"
 ---> Running in fe251123671d
Removing intermediate container fe251123671d
 ---> 9dc3377d1011
Successfully built 9dc3377d1011
```
- Run the rebuilt image:
```
$ docker images
REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
<none>                                              <none>              9dc3377d1011        37 seconds ago      1.11GB
registry.redhat.io/rh-sso-7/sso75-openshift-rhel8   7.5-6               ade02728448c        4 weeks ago         1.11GB
```
```
$ docker run -it 9dc3377d1011
```
- And verify the temporary file, expected to be created by the `${JBOSS_HOME}/extensions/postconfigure.sh` script won't exist:
```
$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED              STATUS              PORTS                          NAMES
7c40ea23e948        9dc3377d1011        "/opt/eap/bin/opensh…"   About a minute ago   Up About a minute   8080/tcp, 8443/tcp, 8778/tcp   vigorous_hoover
```
- Note the expected `/tmp/file_created_with_postconfigure_sh_script` file is missing in the output below:
```
$ docker exec -it 7c40ea23e948 tree /tmp
/tmp
|-- cli-script-1638469638.cli
|-- cli-script-property-1638469638.cli
|-- hsperfdata_jboss
|   `-- 531
|-- hsperfdata_root
|-- jgroups-protocol-adds
|   |-- tcp_protocol_list
|   `-- udp_protocol_list
|-- ks-script-vzv5jj6c
`-- ks-script-y5xeen0d

3 directories, 7 files
```

With the fixed image, the container log contains `Executing postconfigure.sh script...` message & the `/tmp/file_created_with_postconfigure_sh_script` is created (exists in the above output).

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
