### PR TITLE
[CIAM-1495] Explicitly add "com.ongres.scram.client" module as a dependency to the PostgreSQL's "org.postgresql" module

### DIFF
--- a/modules/sso/db/drivers/added/modules/system/layers/openshift/com/ongres/scram/client/main/module.xml
+++ b/modules/sso/db/drivers/added/modules/system/layers/openshift/com/ongres/scram/client/main/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="com.ongres.scram.client">
+  <resources>
+    <resource-root path="ongres-scram-client.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="com.ongres.scram.common" export="true"/>
+  </dependencies>
+</module>

--- a/modules/sso/db/drivers/added/modules/system/layers/openshift/com/ongres/scram/common/main/module.xml
+++ b/modules/sso/db/drivers/added/modules/system/layers/openshift/com/ongres/scram/common/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="com.ongres.scram.common">
+  <resources>
+    <resource-root path="ongres-scram-common.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/modules/sso/db/drivers/added/modules/system/layers/openshift/org/postgresql/main/module.xml
+++ b/modules/sso/db/drivers/added/modules/system/layers/openshift/org/postgresql/main/module.xml
@@ -6,5 +6,19 @@
   <dependencies>
     <module name="javax.api"/>
     <module name="javax.transaction.api"/>
+    <!--
+      ~ CIAM-1495: Explicitly add "com.ongres.scram.client" module as
+      ~ a dependency to the PostgreSQL's "org.postgresql" module to prevent
+      ~ "java.lang.ClassNotFoundException" errors if using PostgreSQL JDBC
+      ~ client with SCRAM-SHA-256 password authentication method. See:
+      ~
+      ~ * https://github.com/pgjdbc/pgjdbc/commit/befea18d153dda7814daef4e036d3f5daf8de1e5
+      ~ * https://github.com/pgjdbc/pgjdbc/commit/1a89290e110d5863b35e0a2ccf79e4292c1056f8
+      ~
+      ~ for more details about the extra Ongres SCRAM library dependency,
+      ~ required by the PostgreSQL JDBC driver, but not packaged into the
+      ~ PostgreSQL driver by default.
+    -->
+    <module name="com.ongres.scram.client" export="true"/>
   </dependencies>
 </module>

--- a/modules/sso/db/drivers/configure.sh
+++ b/modules/sso/db/drivers/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Link DB drivers, provided by RPM packages, into the "openshift" layer
 set -e
 
@@ -6,15 +6,19 @@ set -e
 # shellcheck disable=SC1091
 source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
 
-SCRIPT_DIR=$(dirname $0)
+SCRIPT_DIR=$(dirname "$0")
 ADDED_DIR=${SCRIPT_DIR}/added
 
 function link {
-  mkdir -p $(dirname $2)
-  ln -s $1 $2
+  mkdir -p "$(dirname "$2")"
+  ln -s "$1" "$2"
 }
 
-link /usr/share/java/postgresql-jdbc.jar $JBOSS_HOME/modules/system/layers/openshift/org/postgresql/main/postgresql-jdbc.jar
+# Link the main PostgreSQL JDBC JAR
+link /usr/share/java/postgresql-jdbc.jar "${JBOSS_HOME}"/modules/system/layers/openshift/org/postgresql/main/postgresql-jdbc.jar
+# CIAM-1495: But also the JARs for the Ongres SCRAM library, so it's possible to use SCRAM-SHA-256 password-based auth method
+link /usr/share/java/ongres-scram/common.jar "${JBOSS_HOME}"/modules/system/layers/openshift/com/ongres/scram/common/main/ongres-scram-common.jar
+link /usr/share/java/ongres-scram/client.jar "${JBOSS_HOME}"/modules/system/layers/openshift/com/ongres/scram/client/main/ongres-scram-client.jar
 
 # Remove any existing destination files first (which might be symlinks)
-cp -rp --remove-destination "$ADDED_DIR/modules" "$JBOSS_HOME/"
+cp -rp --remove-destination "${ADDED_DIR}/modules" "${JBOSS_HOME}"


### PR DESCRIPTION
    [CIAM-1495] Explicitly add "com.ongres.scram.client" module as a dependency to
    the PostgreSQL's "org.postgresql" module to prevent
    "java.lang.ClassNotFoundException" errors if using PostgreSQL JDBC client with
    SCRAM-SHA-256 password authentication method. See:
    
    * https://github.com/pgjdbc/pgjdbc/commit/befea18d153dda7814daef4e036d3f5daf8de1e5
    * https://github.com/pgjdbc/pgjdbc/commit/1a89290e110d5863b35e0a2ccf79e4292c1056f8
    
    for more details about the extra Ongres SCRAM library dependency,
    required by the PostgreSQL JDBC driver, but not packaged into the
    PostgreSQL driver by default.
    
    This should fix errors like:
    
    Caused by: java.lang.ClassNotFoundException: com.ongres.scram.common.stringprep.StringPreparation from [Module "org.postgresql" version 42.2.3 from local module loader @59a62269 (finder: local module finder @5644c1b1 (roots: /opt/eap/modules,/opt/eap/modules/system/layers/openshift,/opt/eap/modules/system/layers/keycloak,/opt/eap/modules/system/layers/base))]
            at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:255)
            at org.jboss.modules.ConcurrentClassLoader.performLoadClassUnchecked(ConcurrentClassLoader.java:410)
            at org.jboss.modules.ConcurrentClassLoader.performLoadClass(ConcurrentClassLoader.java:398)
            at org.jboss.modules.ConcurrentClassLoader.loadClass(ConcurrentClassLoader.java:116)
            ... 53 more
    
    seen, when using "scram-sha-256" password authentication method with
    postgresql-jdbc RPM
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
