### PR TITLE
[CIAM-1757] On each arch remove JDK 1.8 rpms if present (since using JDK 11 already)

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -124,17 +124,16 @@ modules:
           - name: openshift-layer
           - name: keycloak-layer
 
-          # Various SSO image pre-launch checks to prevent regressions
-          - name: sso-pre-launch-checks
-
-          # This needs to be the very last, after all updates to standalone-openshift.xml have been done. See eg. https://access.redhat.com/solutions/3402171 for use
+          # The extensions module can be called only after all updates to standalone-openshift.xml have been done.
+          # See eg. https://access.redhat.com/solutions/3402171 for details how to use
           - name: sso-cli-extensions
 
-          # Actions performed by the 'sso-rm-openjdk' module shouldn't be needed for RHEL-8 UBI Minimal
-          # derived images already. But it's kept & called here for any case, so RPMs belonging to
-          # counterpart JVM aren't left in the image by an accident
+          # Ensure RPMs belonging to counterpart JVM are removed
           - name: sso-rm-openjdk
             version: *jdk_version
+
+          # Various SSO image pre-launch checks to prevent regressions
+          - name: sso-pre-launch-checks
 
 packages:
       manager: microdnf

--- a/modules/sso/sso-rm-openjdk/11/configure.sh
+++ b/modules/sso/sso-rm-openjdk/11/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -eu
 
 # Import RH-SSO global variables & functions to image build-time
@@ -15,3 +15,6 @@ if rpm -q ibm-semeru-open-11-jdk || rpm -q java-11-openj9-devel; then
         fi
     done
 fi
+
+# CIAM-1757: On each arch remove JDK 1.8 rpms if present (since using JDK 11 already)
+rpm --query --all name=java* version=1.8.0* | xargs rpm -e --nodeps


### PR DESCRIPTION
    [CIAM-1757] On each arch remove JDK 1.8 rpms if present (since using JDK 11 already)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<hr/>

Testing images for all archs were built in the following pipeline run:
* https://keycloak-jenkins-server.com/view/RH-SSO/job/rh-sso-pipeline-continuous_container/413/

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
