### PR TITLE
[CIAM-2055] Add one-off patch for log4j

### DIFF
--- a/modules/sso/apply/patches/module.yaml
+++ b/modules/sso/apply/patches/module.yaml
@@ -11,6 +11,11 @@ artifacts:
   name: rhsso-1974.zip
   target: eap-one-off-rhsso-1974.zip
   url: http://$DOWNLOAD_SERVER/devel/candidates/JBSSO/JBSSO-7.5.1-CIAM-1974-patch/rhsso-1974.zip
+# CIAM-2055
+- md5: e131a6a7ab26779951981665b9e63919
+  name: rhsso-2054.zip
+  target: eap-one-off-rhsso-2054.zip
+  url: http://$DOWNLOAD_SERVER/devel/candidates/JBSSO/JBSSO-7.5.1-CIAM-2054-patch/rhsso-2054.zip
 
 # Note:
 #

--- a/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
+++ b/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
@@ -11,6 +11,7 @@ function postConfigure() {
   verify_KEYCLOAK_16736_fix_present
   verify_CIAM_1757_fix_present
   verify_CIAM_1975_fix_present
+  verify_CIAM_2055_fix_present
 }
 
 # KEYCLOAK-13585 / RH BZ#1817530 / CVE-2020-10695:
@@ -86,6 +87,20 @@ function verify_CIAM_1975_fix_present() {
   if ! find "${JBOSS_HOME}"/modules/system/layers -name '*-rhsso-1974.jar' 2> /dev/null | grep -q .
   then
     log_error "The CIAM-1975 one-off patch wasn't properly installed."
+    log_error "Cannot start the '${JBOSS_IMAGE_NAME}', version '${JBOSS_IMAGE_VERSION}'!"
+    exit "${errorExitCode}"
+  fi
+}
+
+# CIAM-2055
+#
+# Verify one-off patch for CIAM-2055 got properly installed to the expected location
+#
+function verify_CIAM_2055_fix_present() {
+  local -r errorExitCode="1"
+  if ! find "${JBOSS_HOME}"/modules/system/layers -name '*-rhsso-2054.jar' 2> /dev/null | grep -q .
+  then
+    log_error "The CIAM-2055 one-off patch wasn't properly installed."
     log_error "Cannot start the '${JBOSS_IMAGE_NAME}', version '${JBOSS_IMAGE_VERSION}'!"
     exit "${errorExitCode}"
   fi


### PR DESCRIPTION
    [CIAM-2055] Apply one-off patch for log4j
    Add image prelaunch check to verify it's properly installed
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Ready for review. Testing build succeeded & is available at:
* https://keycloak.jenkins.server.com/view/RH-SSO/job/rh-sso-pipeline-continuous_container/471/

Also double-checked it contains the expected patch

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
