### PR TITLE
[RHSSO-1928] Drop service.alpha.kubernetes.io/tolerate-unready-endpoints: "true" RH-SSO JGroups ping's service annotation. Use 'Service.spec.publishNotReadyAddresses' boolean set to "true" instead

### DIFF
--- a/template.adoc.in
+++ b/template.adoc.in
@@ -205,11 +205,11 @@ For DNS_PING to work, the following steps must be taken:
 . A ping service which exposes the ping port must be defined.  This service
   should be "headless" (ClusterIP=None) and must have the following:
 .. The port must be named for port discovery to work.
-.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
-   set to `"true"`.  Omitting this annotation will result in each node forming
-   their own "cluster of one" during startup, then merging their cluster into
-   the other nodes' clusters after startup (as the other nodes are not detected
-   until after they have started).
+.. The `spec.publishNotReadyAddresses` field of this service must be set to
+   `"true"`. Omitting the setting of this boolean will result in each node
+   forming their own "cluster of one" during startup, then merging their
+   cluster into the other nodes' clusters after startup (as the other nodes are
+   not detected until after they have started).
 
 .Example ping service for use with DNS_PING
 [source,yaml]
@@ -221,12 +221,12 @@ spec:
     ports:
     - name: ping
       port: 8888
+    publishNotReadyAddresses: true
     selector:
         deploymentConfig: eap-app
 metadata:
     name: eap-app-ping
     annotations:
-        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
         description: "The JGroups ping port for clustering."
 ----
 

--- a/templates/sso75-https.json
+++ b/templates/sso75-https.json
@@ -271,6 +271,7 @@
                         "port": 8888
                     }
                 ],
+                "publishNotReadyAddresses": true,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
                 }
@@ -281,7 +282,6 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                     "description": "The JGroups ping port for clustering."
                 }
             }

--- a/templates/sso75-ocp4-x509-https.json
+++ b/templates/sso75-ocp4-x509-https.json
@@ -164,6 +164,7 @@
                         "port": 8888
                     }
                 ],
+                "publishNotReadyAddresses": true,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
                 }
@@ -174,7 +175,6 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret",
                     "description": "The JGroups ping port for clustering."
                 }

--- a/templates/sso75-ocp4-x509-postgresql-persistent.json
+++ b/templates/sso75-ocp4-x509-postgresql-persistent.json
@@ -245,6 +245,7 @@
                         "port": 8888
                     }
                 ],
+                "publishNotReadyAddresses": true,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
                 }
@@ -255,7 +256,6 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret",
                     "description": "The JGroups ping port for clustering."
                 }

--- a/templates/sso75-postgresql-persistent.json
+++ b/templates/sso75-postgresql-persistent.json
@@ -353,6 +353,7 @@
                         "port": 8888
                     }
                 ],
+                "publishNotReadyAddresses": true,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
                 }
@@ -363,7 +364,6 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                     "description": "The JGroups ping port for clustering."
                 }
             }

--- a/templates/sso75-postgresql.json
+++ b/templates/sso75-postgresql.json
@@ -349,6 +349,7 @@
                         "port": 8888
                     }
                 ],
+                "publishNotReadyAddresses": true,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
                 }
@@ -359,7 +360,6 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                     "description": "The JGroups ping port for clustering."
                 }
             }

--- a/templates/sso75-x509-https.json
+++ b/templates/sso75-x509-https.json
@@ -150,6 +150,7 @@
                         "port": 8888
                     }
                 ],
+                "publishNotReadyAddresses": true,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
                 }
@@ -160,7 +161,6 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret",
                     "description": "The JGroups ping port for clustering."
                 }

--- a/templates/sso75-x509-postgresql-persistent.json
+++ b/templates/sso75-x509-postgresql-persistent.json
@@ -331,6 +331,7 @@
                         "port": 8888
                     }
                 ],
+                "publishNotReadyAddresses": true,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
                 }
@@ -341,7 +342,6 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret",
                     "description": "The JGroups ping port for clustering."
                 }


### PR DESCRIPTION
    [RHSSO-1928] Drop service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
    RH-SSO JGroups ping's service annotation, since it's going to be completely
    removed in Kubernetes v1.24 (probably to appear in OCP v4.11):
    
    * https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#deprecation-1
    
    Replace that annotation with 'Service.spec.publishNotReadyAddresses' field (set
    to "true'), which is intended to be used instead
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
