### PR TITLE
[CIAM-800] Fix the failing com.redhat.xpaas.sso.ImageTest.testDeclaredEnvironmentVariables test

### DIFF
--- a/modules/sso/sso-jdk/11/module.yaml
+++ b/modules/sso/sso-jdk/11/module.yaml
@@ -12,7 +12,11 @@ labels:
   value: *jdk_version
 
 envs:
-- name: "JAVA_VERSION"
+- name: JAVA_HOME
+  value: /usr/lib/jvm/java-11
+- name: JAVA_VENDOR
+  value: openjdk
+- name: JAVA_VERSION
   value: *jdk_version
 - name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
   value: /opt/jboss/container/openjdk/jdk


### PR DESCRIPTION
    [CIAM-800] Fix the failing
    com.redhat.xpaas.sso.ImageTest.testDeclaredEnvironmentVariables test --
    the JAVA_HOME and JAVA_VENDOR environment variables are expected to be
    defined this test to pass
    
    The latest JBoss EAP 7.4 with OpenJDK11 for OpenShift container image
    defines these variables since using "jboss.container.openjdk.jdk"
    module:
    
    * https://github.com/jboss-openshift/cct_module/blob/0.45.4/jboss/container/openjdk/jdk/11/module.yaml
    
    But the RH-SSO 7.5.X+ container images don't define these two env
    vars due to the use of internal "sso-jdk/11" module
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

**Note:** Once this is reviewed & merged, it should be merged back to previous `sso75-dev` branch too (so future 7.5.X images have the fix too).

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
