### PR TITLE
[7.6.x] [CIAM-1439] Upgrade tag of the PostgreSQL container image used in templates to "13-el8" 

### DIFF
--- a/docs/templates/sso76-ocp4-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso76-ocp4-x509-postgresql-persistent.adoc
@@ -42,7 +42,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_REALM` | `SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}` | False
 |`SSO_SERVICE_USERNAME` | `SSO_SERVICE_USERNAME` | The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm. | `${SSO_SERVICE_USERNAME}` | False
 |`SSO_SERVICE_PASSWORD` | `SSO_SERVICE_PASSWORD` | The password for the RH-SSO service user. | `${SSO_SERVICE_PASSWORD}` | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream.  Typically, this aligns with the major.minor version of PostgreSQL. | 10 | True
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql13-for-sso76-openshift-rhel8" image stream. | 13-el8 | True
 |`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
 |=======================================================================
 

--- a/docs/templates/sso76-postgresql-persistent.adoc
+++ b/docs/templates/sso76-postgresql-persistent.adoc
@@ -56,7 +56,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE` | `SSO_TRUSTSTORE` | The name of the truststore file within the secret (e.g. truststore.jks) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 10 | True
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql13-for-sso76-openshift-rhel8" image stream. | 13-el8 | True
 |`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
 |=======================================================================
 

--- a/docs/templates/sso76-postgresql.adoc
+++ b/docs/templates/sso76-postgresql.adoc
@@ -55,7 +55,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE` | `SSO_TRUSTSTORE` | The name of the truststore file within the secret (e.g. truststore.jks) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 10 | True
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql13-for-sso76-openshift-rhel8" image stream. | 13-el8 | True
 |`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
 |=======================================================================
 

--- a/docs/templates/sso76-x509-postgresql-persistent.adoc
+++ b/docs/templates/sso76-x509-postgresql-persistent.adoc
@@ -42,7 +42,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_REALM` | `SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}` | False
 |`SSO_SERVICE_USERNAME` | `SSO_SERVICE_USERNAME` | The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm. | `${SSO_SERVICE_USERNAME}` | False
 |`SSO_SERVICE_PASSWORD` | `SSO_SERVICE_PASSWORD` | The password for the RH-SSO service user. | `${SSO_SERVICE_PASSWORD}` | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream.  Typically, this aligns with the major.minor version of PostgreSQL. | 10 | True
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql13-for-sso76-openshift-rhel8" image stream. | 13-el8 | True
 |`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
 |=======================================================================
 

--- a/templates/sso76-image-stream.json
+++ b/templates/sso76-image-stream.json
@@ -1,45 +1,96 @@
 {
-    "kind": "ImageStream",
-    "apiVersion": "image.openshift.io/v1",
+    "kind": "List",
+    "apiVersion": "v1",
     "metadata": {
-        "name": "sso76-openshift-rhel8",
+        "name": "sso76-image-streams",
         "annotations": {
-            "description": "Red Hat Single Sign-On 7.6 on OpenJDK",
-            "openshift.io/display-name": "Red Hat Single Sign-On 7.6 on OpenJDK",
-            "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "7.6.0.GA"
+            "description": "ImageStream definitions for Red Hat Single Sign-On 7.6 on OpenJDK.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
-    "labels": {
-        "rhsso": "7.6.0.GA"
-    },
-    "spec": {
-        "tags": [
-            {
-                "name": "latest",
-                "from": {
-                    "kind": "ImageStreamTag",
-                    "name": "7.6"
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "postgresql13-for-sso76-openshift-rhel8",
+                "creationTimestamp": null,
+                "annotations": {
+                    "openshift.io/display-name": "PostgreSQL"
                 }
             },
-            {
-                "name": "7.6",
-                "annotations": {
-                    "description": "Red Hat Single Sign-On 7.6 on OpenJDK image",
-                    "iconClass": "icon-sso",
-                    "tags": "sso,keycloak,redhat,hidden",
-                    "supports": "sso:7.6",
-                    "version": "1.0",
-                    "openshift.io/display-name": "Red Hat Single Sign-On 7.6 on OpenJDK"
+            "spec": {
+                "lookupPolicy": {
+                    "local": false
                 },
-                "referencePolicy": {
-                    "type": "Local"
-                },
-                "from": {
-                    "kind": "DockerImage",
-                    "name": "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8:7.6"
-                }
+                "tags": [
+                    {
+                        "name": "13-el8",
+                        "annotations": {
+                            "description": "Provides a PostgreSQL 13 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+                            "iconClass": "icon-postgresql",
+                            "openshift.io/display-name": "PostgreSQL 13 (RHEL 8)",
+                            "openshift.io/provider-display-name": "Red Hat, Inc.",
+                            "tags": "database,postgresql",
+                            "version": "13"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/rhel8/postgresql-13:latest"
+                        },
+                        "generation": null,
+                        "importPolicy": {},
+                        "referencePolicy": {
+                            "type": "Local"
+                        }
+                    }
+                ]
             }
-        ]
-    }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "sso76-openshift-rhel8",
+                "annotations": {
+                    "description": "Red Hat Single Sign-On 7.6 on OpenJDK",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.6 on OpenJDK",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "7.6.0.GA"
+                }
+            },
+            "labels": {
+                "rhsso": "7.6.0.GA"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "7.6"
+                        }
+                    },
+                    {
+                        "name": "7.6",
+                        "annotations": {
+                            "description": "Red Hat Single Sign-On 7.6 on OpenJDK image",
+                            "iconClass": "icon-sso",
+                            "tags": "sso,keycloak,redhat,hidden",
+                            "supports": "sso:7.6",
+                            "version": "1.0",
+                            "openshift.io/display-name": "Red Hat Single Sign-On 7.6 on OpenJDK"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8:7.6"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
 }

--- a/templates/sso76-ocp4-x509-postgresql-persistent.json
+++ b/templates/sso76-ocp4-x509-postgresql-persistent.json
@@ -158,7 +158,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "value": "10",
+            "value": "13-el8",
             "required": true
         },
         {
@@ -529,7 +529,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}"
+                                "name": "postgresql13-for-sso76-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}"
                             }
                         }
                     },

--- a/templates/sso76-postgresql-persistent.json
+++ b/templates/sso76-postgresql-persistent.json
@@ -256,7 +256,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "value": "10",
+            "value": "13-el8",
             "required": true
         },
         {
@@ -705,7 +705,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}"
+                                "name": "postgresql13-for-sso76-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}"
                             }
                         }
                     },

--- a/templates/sso76-postgresql.json
+++ b/templates/sso76-postgresql.json
@@ -249,7 +249,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "value": "10",
+            "value": "13-el8",
             "required": true
         },
         {
@@ -706,7 +706,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}"
+                                "name": "postgresql13-for-sso76-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}"
                             }
                         }
                     },

--- a/templates/sso76-x509-postgresql-persistent.json
+++ b/templates/sso76-x509-postgresql-persistent.json
@@ -158,7 +158,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "value": "10",
+            "value": "13-el8",
             "required": true
         },
         {
@@ -252,7 +252,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}"
+                            "name": "postgresql13-for-sso76-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}"
                         },
                         "env": [
                             {
@@ -642,7 +642,7 @@
                                     "successThreshold:": 1,
                                     "failureThreshold": 3,
                                     "exec": {
-                                        "command": [ "/bin/sh", "-i", "-c", "export PGSSLMODE=\"require\" && psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
+                                        "command": [ "/bin/sh", "-i", "-c", "PGSSLMODE=require psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"]
                                     }
                                 },
                                 "livenessProbe": {


### PR DESCRIPTION
**Note:** This is the same change like in [corresponding PR against RH-SSO 7.5.X](), but for RH-SSO 7.6.X stream of images.
The only differences are different template file names, and slightly different (though based on the very same idea)
changes performed in the ` templates/sso76-image-stream.json`

    [CIAM-1439] Upgrade version of the PostgreSQL server used in templates
    for the Red Hat Single Sign-On 7.6 on OpenJDK for OpenShift container
    images to PostgreSQL v13.5
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

**Testing report:** I have manually tried to create the `sso76-image-stream.json` image stream, the `sso76-x509-postgresql-persistent.json` template, imported the RH-SSO 7.6.0.GA OpenShift image from [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/rh-sso-7/sso76-openshift-rhel8/629651e2cddbbde600c0a2ec?container-tabs=gti), and using standard oc CLI:
```
]$ oc new-app --template=sso76-x509-postgresql-persistent
```
both the PostgreSQL v13 & RH-SSO 7.6.0.GA pods are running fine.

@Pepo48 PTAL once got a chance

Thanks!
Jan

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
