### PR TITLE
[RHSSO-2017] Escape XML special characters to their corresponding XML escape sequences when present in input

### DIFF
--- a/modules/eap/setup/eap/modules/added/https.sh
+++ b/modules/eap/setup/eap/modules/added/https.sh
@@ -69,6 +69,10 @@ function configureSslXml() {
             </ssl>\n\
         </server-identities>"
 
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  ssl=$(escape_sed_rhs_interpolated_characters "${ssl}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ##SSL## -->${AUS}${ssl}${AUS}" $CONFIG_FILE
   # EOF CIAM-1394 correction
@@ -98,6 +102,7 @@ EOF
 
 function configureHttpsXml() {
   https_connector="<https-listener name=\"https\" socket-binding=\"https\" security-realm=\"ApplicationRealm\" proxy-address-forwarding=\"true\"/>"
+  # RHSSO-2017 Escape special characters for sed RHS fix not needed since "https_connector" has only static content
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ##HTTPS_CONNECTOR## -->${AUS}${https_connector}${AUS}" $CONFIG_FILE
   # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/access_log_valve.sh
+++ b/modules/eap/setup/eap/modules/added/launch/access_log_valve.sh
@@ -46,6 +46,10 @@ function configure_access_log_valve() {
     if [ "${mode}" == "xml" ]; then
       local pattern=$(getPattern "add-xml")
       local valve="<access-log use-server-log=\"true\" pattern=\"${pattern}\"/>"
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      valve=$(escape_sed_rhs_interpolated_characters "${valve}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}<!-- ##ACCESS_LOG_VALVE## -->${AUS}${valve}${AUS}" $CONFIG_FILE
       # EOF CIAM-1394 correction
@@ -186,6 +190,10 @@ function configure_access_log_handler() {
     getConfigurationMode "<!-- ##ACCESS_LOG_HANDLER## -->" "mode"
 
     if [ "${mode}" = "xml" ]; then
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      log_category=$(escape_sed_rhs_interpolated_characters "${log_category}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}<!-- ##ACCESS_LOG_HANDLER## -->${AUS}<logger category=\"${log_category}\"><level name=\"TRACE\"/></logger>${AUS}" $CONFIG_FILE
       # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/datasource-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/datasource-common.sh
@@ -109,6 +109,10 @@ function inject_internal_datasources() {
       local dsConfMode
       getDataSourceConfigureMode "dsConfMode"
       if [ "${dsConfMode}" = "xml" ]; then
+        # RHSSO-2017 Escape possible ampersand and semicolong characters
+        # which are interpolated when used in sed righ-hand side expression
+        datasource=$(escape_sed_rhs_interpolated_characters "${datasource}")
+        # EOF RHSSO-2017 correction
         # CIAM-1394 correction
         sed -i "s${AUS}<!-- ##DATASOURCES## -->${AUS}${datasource}<!-- ##DATASOURCES## -->${AUS}" $CONFIG_FILE
         # EOF CIAM-1394 correction
@@ -199,6 +203,10 @@ function writeEEDefaultDatasourceXml() {
   else
     defaultDatasource=""
   fi
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  defaultDatasource=$(escape_sed_rhs_interpolated_characters "${defaultDatasource}")
+  # EOF RHSSO-2017 correction
   # new format replacement : datasource="##DEFAULT_DATASOURCE##"
   # CIAM-1394 correction
   sed -i "s${AUS}datasource=\"##DEFAULT_DATASOURCE##\"${AUS}${defaultDatasource}${AUS}" $CONFIG_FILE
@@ -766,6 +774,10 @@ function inject_default_timer_service() {
                       <file-data-store name=\"default-file-store\" path=\"timer-service-data\" relative-to=\"jboss.server.data.dir\"/>\
                   </data-stores>\
               </timer-service>"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    timerservice=$(escape_sed_rhs_interpolated_characters "${timerservice}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##TIMER_SERVICE## -->${AUS}${timerservice}${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction
@@ -815,6 +827,10 @@ function inject_timer_service() {
                     <database-data-store name=\"${datastore_name}\" datasource-jndi-name=\"${jndi_name}\" database=\"${databasename}\" partition=\"${pool_name}_part\" refresh-interval=\"${refresh_interval}\"/>
                   </data-stores>\
               </timer-service>"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    timerservice=$(escape_sed_rhs_interpolated_characters "${timerservice}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##TIMER_SERVICE## -->${AUS}${timerservice}${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction
@@ -1059,6 +1075,10 @@ function inject_datasource() {
       local dsConfMode
       getDataSourceConfigureMode "dsConfMode"
       if [ "${dsConfMode}" = "xml" ]; then
+        # RHSSO-2017 Escape possible ampersand and semicolong characters
+        # which are interpolated when used in sed righ-hand side expression
+        datasource=$(escape_sed_rhs_interpolated_characters "${datasource}")
+        # EOF RHSSO-2017 correction
         # CIAM-1394 correction
         sed -i "s${AUS}<!-- ##DATASOURCES## -->${AUS}${datasource}\n<!-- ##DATASOURCES## -->${AUS}" $CONFIG_FILE
         # EOF CIAM-1394 correction
@@ -1087,6 +1107,10 @@ function inject_default_job_repository() {
   getConfigurationMode "<!-- ##DEFAULT_JOB_REPOSITORY## -->" "dsConfMode"
   if [ "${dsConfMode}" = "xml" ]; then
     local defaultjobrepo="     <default-job-repository name=\"${1}\"/>"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    defaultjobrepo=$(escape_sed_rhs_interpolated_characters "${defaultjobrepo}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##DEFAULT_JOB_REPOSITORY## -->${AUS}${defaultjobrepo%$'\n'}${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction
@@ -1131,6 +1155,10 @@ function inject_job_repository() {
       </job-repository>\
       <!-- ##JOB_REPOSITORY## -->"
 
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    jobrepo=$(escape_sed_rhs_interpolated_characters "${jobrepo}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##JOB_REPOSITORY## -->${AUS}${jobrepo%$'\n'}${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/datasource.sh
+++ b/modules/eap/setup/eap/modules/added/launch/datasource.sh
@@ -37,6 +37,10 @@ function configureEnv() {
   # TODO - I don't think this is being used any more? The real action seems to be in tx-datasource.sh
   if [ -n "$JDBC_STORE_JNDI_NAME" ]; then
     local jdbcStore="<jdbc-store datasource-jndi-name=\"${JDBC_STORE_JNDI_NAME}\"/>"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    jdbcStore=$(escape_sed_rhs_interpolated_characters "${jdbcStore}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##JDBC_STORE## -->${AUS}${jdbcStore}${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/deploymentScanner.sh
+++ b/modules/eap/setup/eap/modules/added/launch/deploymentScanner.sh
@@ -24,6 +24,10 @@ function configure_deployment_scanner() {
   getConfigurationMode "##AUTO_DEPLOY_EXPLODED##" "configure_mode"
 
   if [ "${configure_mode}" = "xml" ]; then
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    auto_deploy_exploded=$(escape_sed_rhs_interpolated_characters "${auto_deploy_exploded}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}##AUTO_DEPLOY_EXPLODED##${AUS}${auto_deploy_exploded}${AUS}" "$CONFIG_FILE"
     # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/elytron.sh
+++ b/modules/eap/setup/eap/modules/added/launch/elytron.sh
@@ -69,6 +69,10 @@ insert_elytron_tls() {
          </tls>\n"
     # check for new config tag, use that if it's present, note we remove the <!-- ##ELYTRON_TLS## --> on first substitution
     if [ "true" = $(has_elytron_tls "${CONFIG_FILE}") ]; then
+        # RHSSO-2017 Escape possible ampersand and semicolong characters
+        # which are interpolated when used in sed righ-hand side expression
+        elytron_tls=$(escape_sed_rhs_interpolated_characters "${elytron_tls}")
+        # EOF RHSSO-2017 correction
         # CIAM-1394 correction
         sed -i "s${AUS}<!-- ##ELYTRON_TLS## -->${AUS}${elytron_tls}${AUS}" $CONFIG_FILE
         # EOF CIAM-1394 correction
@@ -293,6 +297,12 @@ configure_https() {
           # insert the new config element, only if it hasn't been added already
           insert_elytron_tls_config_if_needed "${CONFIG_FILE}"
           # insert the individual config blocks we leave the replacement tags around in case something else (e.g. jgoups might need to add a keystore etc)
+          # RHSSO-2017 Escape possible ampersand and semicolong characters
+          # which are interpolated when used in sed righ-hand side expression
+          elytron_key_store=$(escape_sed_rhs_interpolated_characters "${elytron_key_store}")
+          elytron_key_manager=$(escape_sed_rhs_interpolated_characters "${elytron_key_manager}")
+          elytron_server_ssl_context=$(escape_sed_rhs_interpolated_characters "${elytron_server_ssl_context}")
+          # EOF RHSSO-2017 correction
           # CIAM-1394 correction
           sed -i "s${AUS}<!-- ##ELYTRON_KEY_STORE## -->${AUS}${elytron_key_store}<!-- ##ELYTRON_KEY_STORE## -->${AUS}" $CONFIG_FILE
           sed -i "s${AUS}<!-- ##ELYTRON_KEY_MANAGER## -->${AUS}${elytron_key_manager}<!-- ##ELYTRON_KEY_MANAGER## -->${AUS}" $CONFIG_FILE
@@ -302,6 +312,10 @@ configure_https() {
           legacy_elytron_tls=$(elytron_legacy_config "${elytron_key_store}" "${elytron_key_manager}" "${elytron_server_ssl_context}")
       fi
       # will be empty unless only the old marker is present.
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      legacy_elytron_tls=$(escape_sed_rhs_interpolated_characters "${legacy_elytron_tls}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}<!-- ##TLS## -->${AUS}${legacy_elytron_tls}${AUS}" $CONFIG_FILE
       # EOF CIAM-1394 correction
@@ -315,6 +329,10 @@ configure_https() {
     getConfigurationMode "<!-- ##HTTPS_CONNECTOR## -->" "elytron_https_connector_conf_mode"
     if [ "${elytron_https_connector_conf_mode}" = "xml" ]; then
       local elytron_https_connector=$(create_elytron_https_connector "https" "https" "LocalhostSslContext" "true")
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      elytron_https_connector=$(escape_sed_rhs_interpolated_characters "${elytron_https_connector}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}<!-- ##HTTPS_CONNECTOR## -->${AUS}${elytron_https_connector}${AUS}" $CONFIG_FILE
       # EOF CIAM-1394 correction
@@ -391,6 +409,11 @@ configure_elytron_integration() {
           </security-realms>\n\
     </elytron-integration>"
 
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    elytron_integration=$(escape_sed_rhs_interpolated_characters "${elytron_integration}")
+    elytron_realm=$(escape_sed_rhs_interpolated_characters "${elytron_realm}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##ELYTRON_INTEGRATION## -->${AUS}${elytron_integration}${AUS}" $CONFIG_FILE
     sed -i "s${AUS}<!-- ##INTEGRATION_ELYTRON_REALM## -->${AUS}${elytron_realm}<!-- ##INTEGRATION_ELYTRON_REALM## -->${AUS}" $CONFIG_FILE
@@ -415,6 +438,10 @@ configure_elytron_security_domain() {
                       <realm name=\"${SECDOMAIN_NAME}\"/>\n\
                   </security-domain>"
 
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    elytron_security_domain=$(escape_sed_rhs_interpolated_characters "${elytron_security_domain}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##ELYTRON_SECURITY_DOMAIN## -->${AUS}${elytron_security_domain}<!-- ##ELYTRON_SECURITY_DOMAIN## -->${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction
@@ -442,6 +469,10 @@ configure_http_authentication_factory() {
                       </mechanism-configuration>\n\
                   </http-authentication-factory>"
 
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      http_authentication_factory=$(escape_sed_rhs_interpolated_characters "${http_authentication_factory}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}<!-- ##HTTP_AUTHENTICATION_FACTORY## -->${AUS}${http_authentication_factory}<!-- ##HTTP_AUTHENTICATION_FACTORY## -->${AUS}" $CONFIG_FILE
       # EOF CIAM-1394 correction
@@ -466,6 +497,11 @@ configure_http_application_security_domains() {
                 <!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->\
             </application-security-domains>"
 
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    http_application_security_domains=$(escape_sed_rhs_interpolated_characters "${http_application_security_domains}")
+    application_security_domain=$(escape_sed_rhs_interpolated_characters "${application_security_domain}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##HTTP_APPLICATION_SECURITY_DOMAINS## -->${AUS}${http_application_security_domains}${AUS}" $CONFIG_FILE
     sed -i "s${AUS}<!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->${AUS}${application_security_domain}<!-- ##HTTP_APPLICATION_SECURITY_DOMAIN## -->${AUS}" $CONFIG_FILE
@@ -491,6 +527,11 @@ configure_ejb_application_security_domains() {
                 <!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->\
             </application-security-domains>"
 
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    ejb_application_security_domains=$(escape_sed_rhs_interpolated_characters "${ejb_application_security_domains}")
+    application_security_domain=$(escape_sed_rhs_interpolated_characters "${application_security_domain}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##EJB_APPLICATION_SECURITY_DOMAINS## -->${AUS}${ejb_application_security_domains}${AUS}" $CONFIG_FILE
     sed -i "s${AUS}<!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->${AUS}${application_security_domain}<!-- ##EJB_APPLICATION_SECURITY_DOMAIN## -->${AUS}" $CONFIG_FILE

--- a/modules/eap/setup/eap/modules/added/launch/ha.sh
+++ b/modules/eap/setup/eap/modules/added/launch/ha.sh
@@ -323,6 +323,10 @@ configure_ha() {
   fi
 
   if [ "${CONF_AUTH_MODE}" = "xml" ]; then
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    JGROUPS_AUTH=$(escape_sed_rhs_interpolated_characters "${JGROUPS_AUTH}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##JGROUPS_AUTH## -->${AUS}${JGROUPS_AUTH}${AUS}g" $CONFIG_FILE
     # EOF CIAM-1394 correction
@@ -333,6 +337,10 @@ configure_ha() {
   log_info "Configuring JGroups discovery protocol to ${ping_protocol}"
 
   if [ "${CONF_PING_MODE}" = "xml" ]; then
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    ping_protocol_element=$(escape_sed_rhs_interpolated_characters "${ping_protocol_element}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##JGROUPS_PING_PROTOCOL## -->${AUS}${ping_protocol_element}${AUS}g" $CONFIG_FILE
     # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/jgroups.sh
+++ b/modules/eap/setup/eap/modules/added/launch/jgroups.sh
@@ -387,6 +387,10 @@ configure_jgroups_encryption() {
   esac
 
   if [ "${key_store_conf_mode}" = "xml" ]; then
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    key_store=$(escape_sed_rhs_interpolated_characters "${key_store}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##ELYTRON_KEY_STORE## -->${AUS}${key_store}<!-- ##ELYTRON_KEY_STORE## -->${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction
@@ -395,6 +399,10 @@ configure_jgroups_encryption() {
   fi
 
   if [ "${encrypt_conf_mode}" = "xml" ]; then
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    jgroups_encrypt=$(escape_sed_rhs_interpolated_characters "${jgroups_encrypt}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##JGROUPS_ENCRYPT## -->${AUS}${jgroups_encrypt}${AUS}g" "$CONFIG_FILE"
     # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/login-modules-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/login-modules-common.sh
@@ -24,6 +24,10 @@ function configure_login_modules() {
         getConfigurationMode "<!-- ##OTHER_LOGIN_MODULES## -->" "confMode"
 
         if [ "${confMode}" = "xml" ]; then
+          # RHSSO-2017 Escape possible ampersand and semicolong characters
+          # which are interpolated when used in sed righ-hand side expression
+          login_modules=$(escape_sed_rhs_interpolated_characters "${login_modules}")
+          # EOF RHSSO-2017 correction
           # CIAM-1394 correction
           sed -i "s${AUS}<!-- ##OTHER_LOGIN_MODULES## -->${AUS}${login_modules}<!-- ##OTHER_LOGIN_MODULES## -->${AUS}" "$CONFIG_FILE"
           # EOF CIAM-1394 correction
@@ -59,5 +63,5 @@ configure_login_module_cli() {
           $add_login_module
         end-if
 EOF
-   
+
 }

--- a/modules/eap/setup/eap/modules/added/launch/management-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/management-common.sh
@@ -15,6 +15,10 @@ function add_management_interface_realm() {
 
     if [ "${mode}" = "xml" ]; then
       mgmt_iface_replace_str=" security-realm=\"$mgmt_iface_realm\">"
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      mgmt_iface_replace_str=$(escape_sed_rhs_interpolated_characters "${mgmt_iface_replace_str}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}><!-- ##MGMT_IFACE_REALM## -->${AUS}${mgmt_iface_replace_str}${AUS}" "$CONFIG_FILE"
       # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/ports.sh
+++ b/modules/eap/setup/eap/modules/added/launch/ports.sh
@@ -20,6 +20,10 @@ function configure_port_offset() {
     getConfigurationMode "port-offset=\"0\"" "mode"
 
     if [ "${mode}" = "xml" ]; then
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      PORT_OFFSET=$(escape_sed_rhs_interpolated_characters "${PORT_OFFSET}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}port-offset=\"0\"${AUS}port-offset=\"${PORT_OFFSET}\"${AUS}g" "$CONFIG_FILE"
       # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/resource-adapters-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/resource-adapters-common.sh
@@ -87,6 +87,10 @@ function inject_resource_adapters_common() {
     resource_adapters=$(echo "${resource_adapters}" | sed -e "s${AUS}localhost${AUS}${hostname}${AUS}g")
     # EOF CIAM-1394 correction
     if [ "${mode}" = "xml" ]; then
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      resource_adapters=$(escape_sed_rhs_interpolated_characters "${resource_adapters}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}<!-- ##RESOURCE_ADAPTERS## -->${AUS}${resource_adapters}<!-- ##RESOURCE_ADAPTERS## -->${AUS}" $CONFIG_FILE
       # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/security-domains.sh
+++ b/modules/eap/setup/eap/modules/added/launch/security-domains.sh
@@ -55,6 +55,10 @@ configure_security_domains() {
             </authentication>\n\
         </security-domain>\n"
 
+      # RHSSO-2017 Escape possible ampersand and semicolong characters
+      # which are interpolated when used in sed righ-hand side expression
+      domains=$(escape_sed_rhs_interpolated_characters "${domains}")
+      # EOF RHSSO-2017 correction
       # CIAM-1394 correction
       sed -i "s${AUS}<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->${AUS}${domains}<!-- ##ADDITIONAL_SECURITY_DOMAINS## -->${AUS}" "$CONFIG_FILE"
       # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/added/launch/tx-datasource.sh
+++ b/modules/eap/setup/eap/modules/added/launch/tx-datasource.sh
@@ -70,6 +70,10 @@ function inject_jdbc_store() {
               <communication table-prefix=\"${prefix}\"/>\\
               <state table-prefix=\"${prefix}\"/>\\
           </jdbc-store>"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    jdbcStore=$(escape_sed_rhs_interpolated_characters "${jdbcStore}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##JDBC_STORE## -->${AUS}${jdbcStore}${AUS}" $CONFIG_FILE
     # EOF CIAM-1394 correction
@@ -210,6 +214,10 @@ function inject_tx_datasource() {
       if [ "${dsConfMode}" = "xml" ]; then
         # Only do this replacement if we are replacing an xml marker
         datasource_adjusted="$(echo ${datasource} | sed ':a;N;$!ba;s|\n|\\n|g')"
+        # RHSSO-2017 Escape possible ampersand and semicolong characters
+        # which are interpolated when used in sed righ-hand side expression
+        datasource_adjusted=$(escape_sed_rhs_interpolated_characters "${datasource_adjusted}")
+        # EOF RHSSO-2017 correction
         # CIAM-1394 correction
         sed -i "s${AUS}<!-- ##DATASOURCES## -->${AUS}${datasource_adjusted}<!-- ##DATASOURCES## -->${AUS}" $CONFIG_FILE
         # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/eap/galleon/patching.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/eap/galleon/patching.sh
@@ -4,6 +4,10 @@ mavenRepo="$1"
 if [ -f "$mavenRepo/patches.xml" ]; then
   echo "The maven repository has been patched, setting patches in galleon feature-pack."
   patches=`cat "$mavenRepo/patches.xml" | sed ':a;N;$!ba;s/\n//g'`
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  patches=$(escape_sed_rhs_interpolated_characters "${patches}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ##PATCHES## -->${AUS}$patches${AUS}" "${GALLEON_FP_PATH}/wildfly-user-feature-pack-build.xml"
   # EOF CIAM-1394 correction

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/maven.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/maven.sh
@@ -17,7 +17,7 @@ function maven_init_vars() {
   maven_init_var_MAVEN_SETTINGS_XML
   maven_init_var_MAVEN_OPTS
   maven_init_var_MAVEN_ARGS
-  
+
   maven_init_backward_compatibility
 }
 
@@ -83,13 +83,13 @@ function maven_build() {
   log_info "Running 'mvn $MAVEN_ARGS $goals'"
   # Execute the actual build
   mvn $MAVEN_ARGS $goals
-  
+
   popd &> /dev/null
-  
+
 }
 
 # post build cleanup.  deletes local repository after a build, if MAVEN_CLEAR_REPO is set
-function maven_cleanup() { 
+function maven_cleanup() {
   # Remove repo if desired
   if [ "${MAVEN_CLEAR_REPO,,}" == "true" -a -n "$(find ${MAVEN_LOCAL_REPO} -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
     log_info "Clearing local maven repository at ${MAVEN_LOCAL_REPO}"
@@ -151,6 +151,10 @@ function _add_maven_proxy() {
   xml="$xml\
        </proxy>"
     local sub="<!-- ### configured http proxy ### -->"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    xml=$(escape_sed_rhs_interpolated_characters "${xml}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}${sub}${AUS}${xml}${AUS}" "$settings"
     # EOF CIAM-1394 correction
@@ -233,6 +237,10 @@ function _add_maven_mirror() {
     </mirror>\n\
     <!-- ### configured mirrors ### -->"
 
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  xml=$(escape_sed_rhs_interpolated_characters "${xml}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ### configured mirrors ### -->${AUS}$xml${AUS}" "${settings}"
   # EOF CIAM-1394 correction
@@ -245,6 +253,10 @@ function add_maven_repos() {
   # set the local repository
   local local_repo_xml="\n\
   <localRepository>${MAVEN_LOCAL_REPO}</localRepository>"
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  local_repo_xml=$(escape_sed_rhs_interpolated_characters "${local_repo_xml}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ### configured local repository ### -->${AUS}${local_repo_xml}${AUS}" "${settings}"
   # EOF CIAM-1394 correction
@@ -350,6 +362,10 @@ function _add_maven_repo_profile() {
     </repositories>\n\
   </profile>\n\
   <!-- ### configured profiles ### -->"
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  xml=$(escape_sed_rhs_interpolated_characters "${xml}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ### configured profiles ### -->${AUS}${xml}${AUS}" "${settings}"
   # EOF CIAM-1394 correction
@@ -358,6 +374,10 @@ function _add_maven_repo_profile() {
   xml="\n\
     <activeProfile>${profile_id}</activeProfile>\n\
     <!-- ### active profiles ### -->"
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  xml=$(escape_sed_rhs_interpolated_characters "${xml}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ### active profiles ### -->${AUS}${xml}${AUS}" "${settings}"
   # EOF CIAM-1394 correction
@@ -400,6 +420,10 @@ function _add_maven_repo_server() {
   xml="${xml}\n\
     </server>\n\
     <!-- ### configured servers ### -->"
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  xml=$(escape_sed_rhs_interpolated_characters "${xml}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ### configured servers ### -->${AUS}${xml}${AUS}" "${settings}"
   # EOF CIAM-1394 correction
@@ -430,7 +454,7 @@ function copy_artifacts() {
     types="$types;$1"
     shift
   done
-  
+
   for d in $(echo $dir | tr "," "\n")
   do
     shift

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
@@ -12,6 +12,10 @@ function galleon_patch_generic_config() {
        fi
      done
      if [ -n "$layers" ]; then
+       # RHSSO-2017 Escape possible ampersand and semicolong characters
+       # which are interpolated when used in sed righ-hand side expression
+       layers=$(escape_sed_rhs_interpolated_characters "${layers}")
+       $ EOF RHSSO-2017 correction
        # CIAM-1394 correction
        sed -i "s${AUS}<!-- ##GALLEON_LAYERS## -->${AUS}${layers}${AUS}" $GALLEON_GENERIC_LAYERS_DEFINITION/config.xml
        # EOF CIAM-1394 correction
@@ -24,6 +28,10 @@ function galleon_patch_generic_config() {
        featurepacks="$featurepacks<location>$fp</location></feature-pack>"
      done
      if [ -n "$featurepacks" ]; then
+       # RHSSO-2017 Escape possible ampersand and semicolong characters
+       # which are interpolated when used in sed righ-hand side expression
+       featurepacks=$(escape_sed_rhs_interpolated_characters "${featurepacks}")
+       # EOF RHSSO-2017 correction
        # CIAM-1394 correction
        sed -i "s${AUS}<!-- ##GALLEON_FEATURE_PACKS## -->${AUS}${featurepacks}${AUS}" $GALLEON_GENERIC_LAYERS_DEFINITION/pom.xml
        # EOF CIAM-1394 correction
@@ -121,7 +129,7 @@ function galleon_init_mvn_env() {
     # Need to compute the project src root dir.
     dest_dir="${S2I_DESTINATION_DIR:-/tmp}"
     GALLEON_PROJECT_SRC_DIR="${dest_dir}/src"
-    
+
     # Identify custom galleon content directory
     if [ -n "${GALLEON_DIR}" ]; then
       GALLEON_LOCAL_PROVISIONING="${GALLEON_PROJECT_SRC_DIR}/${GALLEON_DIR}"
@@ -152,7 +160,7 @@ function galleon_init_mvn_env() {
     unset MAVEN_ARGS
     unset MAVEN_REPO_LOCAL
     #capture default Maven ARGS
-    maven_init_var_MAVEN_ARGS    
+    maven_init_var_MAVEN_ARGS
     # Add settings that Galleon plugin will use when generating config
     MAVEN_ARGS="$MAVEN_ARGS -Djboss.modules.settings.xml.url=file://$GALLEON_MAVEN_SETTINGS_XML"
 }
@@ -261,7 +269,7 @@ function galleon_provision_server() {
         exit 1
       fi
     fi
-    
+
     if [ -z "$GALLEON_DESCRIPTION_LOCATION" ]; then
         if [ -z "$GALLEON_PROVISION_SERVER" ]; then
           if [ -d $GALLEON_LOCAL_PROVISIONING ]; then
@@ -296,7 +304,7 @@ function galleon_provision_server() {
     fi
 
     if [ ! -z "$GALLEON_DESCRIPTION_LOCATION" ]; then
-      
+
       if [ -f "$GALLEON_DESCRIPTION_LOCATION/pom.xml" ]; then
           echo "Provisioning WildFly server..."
           maven_build "$GALLEON_DESCRIPTION_LOCATION" package

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
@@ -104,6 +104,10 @@ function configure_drivers(){
 
       if [ -n "$drivers" ] ; then
         if [ "${configMode}" = "xml" ]; then
+          # RHSSO-2017 Escape possible ampersand and semicolong characters
+          # which are interpolated when used in sed righ-hand side expression
+          drivers=$(escape_sed_rhs_interpolated_characters "${drivers}")
+          # EOF RHSSO-2017 correction
           # CIAM-1394 correction
           sed -i "s${AUS}<!-- ##DRIVERS## -->${AUS}${drivers}<!-- ##DRIVERS## -->${AUS}" $CONFIG_FILE
           # EOF CIAM-1394 correction

--- a/modules/sso/config/launch/setup/75/added/launch/datasource.sh
+++ b/modules/sso/config/launch/setup/75/added/launch/datasource.sh
@@ -118,6 +118,10 @@ function inject_default_job_repositories() {
 # $1 - default job repository name
 function inject_default_job_repository() {
   defaultjobrepo="     <default-job-repository name=\"${1}\"/>"
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  defaultjobrepo=$(escape_sed_rhs_interpolated_characters "${defaultjobrepo}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ##DEFAULT_JOB_REPOSITORY## -->${AUS}${defaultjobrepo%$'\n'}${AUS}" $CONFIG_FILE
   # EOF CIAM-1394 correction
@@ -128,6 +132,10 @@ function inject_job_repository() {
       <jdbc data-source=\"${1}\"/>\
     </job-repository>\
     <!-- ##JOB_REPOSITORY## -->"
+  # RHSSO-2017 Escape possible ampersand and semicolong characters
+  # which are interpolated when used in sed righ-hand side expression
+  jobrepo=$(escape_sed_rhs_interpolated_characters "${jobrepo}")
+  # EOF RHSSO-2017 correction
   # CIAM-1394 correction
   sed -i "s${AUS}<!-- ##JOB_REPOSITORY## -->${AUS}${jobrepo%$'\n'}${AUS}" $CONFIG_FILE
   # EOF CIAM-1394 correction

--- a/modules/sso/config/launch/setup/75/added/launch/keycloak-spi.sh
+++ b/modules/sso/config/launch/setup/75/added/launch/keycloak-spi.sh
@@ -22,6 +22,10 @@ function add_truststore() {
 
     local truststore="<spi name=\"truststore\"><provider name=\"file\" enabled=\"true\"><properties><property name=\"file\" value=\"${SSO_TRUSTSTORE_DIR}/${SSO_TRUSTSTORE}\"/><property name=\"password\" value=\"${SSO_TRUSTSTORE_PASSWORD}\"/><property name=\"hostname-verification-policy\" value=\"WILDCARD\"/><property name=\"disabled\" value=\"false\"/></properties></provider></spi>"
 
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    truststore=$(escape_sed_rhs_interpolated_characters "${truststore}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##SSO_TRUSTSTORE## -->${AUS}${truststore}${AUS}" "${CONFIG_FILE}"
     # EOF CIAM-1394 correction
@@ -34,6 +38,10 @@ function add_vault() {
   if [ -n "$SSO_VAULT_DIR" ]; then
 
     local vault="<spi name=\"vault\"><default-provider>files-plaintext</default-provider><provider name=\"files-plaintext\" enabled=\"true\"><properties><property name=\"dir\" value=\"${SSO_VAULT_DIR}\"/></properties></provider></spi>"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    vault=$(escape_sed_rhs_interpolated_characters "${vault}")
+    # EOF RHSSO-2017 correction
     # CIAM-1394 correction
     sed -i "s${AUS}<!-- ##SSO_VAULT_CONFIG## -->${AUS}${vault}${AUS}" "${CONFIG_FILE}"
     # EOF CIAM-1394 correction
@@ -48,6 +56,10 @@ function set_server_hostname_spi_to_default() {
     local properties=''
     if [ -n "${SSO_FRONTEND_URL:-$KEYCLOAK_FRONTEND_URL}" ]; then
         properties+="<property name=\"frontendUrl\" value=\"${SSO_FRONTEND_URL:-$KEYCLOAK_FRONTEND_URL}\"/>"
+        # RHSSO-2017 Escape possible ampersand and semicolong characters
+        # which are interpolated when used in sed righ-hand side expression
+        properties=$(escape_sed_rhs_interpolated_characters "${properties}")
+        # EOF RHSSO-2017 correction
     fi
     local -r hostname_spi="<spi name=\"hostname\"><default-provider>default</default-provider><provider name=\"default\" enabled=\"true\"><properties>${properties}</properties></provider></spi>"
 
@@ -69,6 +81,11 @@ function set_server_hostname_spi_to_fixed() {
     fi
 
     local -r requested_hostname="$1"
+    # RHSSO-2017 Escape possible ampersand and semicolong characters
+    # which are interpolated when used in sed righ-hand side expression
+    requested_hostname=$(escape_sed_rhs_interpolated_characters "${requested_hostname}")
+    # EOF RHSSO-2017 correction
+
     local -r hostname_spi="<spi name=\"hostname\"><default-provider>fixed</default-provider><provider name=\"fixed\" enabled=\"true\"><properties><property name=\"hostname\" value=\"${requested_hostname}\"/><property name=\"httpPort\" value=\"-1\"/><property name=\"httpsPort\" value=\"-1\"/><property name=\"alwaysHttps\" value=\"false\"/></properties></provider></spi>"
 
     # CIAM-1394 correction

--- a/modules/sso/rcfile/sso-rcfile-definitions.sh
+++ b/modules/sso/rcfile/sso-rcfile-definitions.sh
@@ -7,7 +7,7 @@ set -e
 #       checking if some optional runtime env var was specified or not
 
 
-### RH-SSO global variables & functions
+### RH-SSO globally used variables
 
 # CIAM-1394 Use a non-printable character - ASCII 31 (octal 037) unit
 # separator character as the sed substitute (s) command delimiter for each
@@ -25,3 +25,166 @@ set -e
 # type of errors
 # shellcheck disable=SC2034
 export readonly AUS=$'\037'
+
+### RH-SSO globally used functions
+
+# RHSSO-2017 Escape XML special characters to XML escape sequences
+function escape_xml_characters() {
+  if [[ "$#" -eq "1" ]]
+  then
+    # Assume the input to be partially XML escaped already
+    # Start with XML escaping the ampersand character -- since the input can
+    # contain both plain ampersand character and XML escape sequences starting
+    # with ampersand too, first unescape the XML escape sequences back to plain
+    # characters to identify the occurences of just the plain ampersand
+    # character itself. Decode the XML escape sequences using the mapping:
+    #
+    # https://www.ibm.com/docs/en/was-liberty/base?topic=manually-xml-escape-characters
+    #
+    input="${1//&amp;/&}"
+    input="${input//&apos;/\'}"
+    input="${input//&gt;/>}"
+    input="${input//&lt;/<}"
+    input="${input//&quot;/\"}"
+    # Now the ampersand characters still present (remaining) in the input
+    # truly represent just the plain ampersand character that should be escaped
+    input="${input//&/&amp;}"
+    # All ampersands are handled. Now it's safe to XML escape the remaining four
+    # characters
+    input="${input//\'/&apos;}"
+    input="${input//>/&gt;}"
+    input="${input//</&lt;}"
+    input="${input//\"/&quot;}"
+    # Return the resulting XML escaped string
+    echo "${input}"
+  else
+    echo "Please specify exactly one string to be XML escaped."
+    exit 1
+  fi
+}
+
+# RHSSO-2017 Convert XML special characters present in values of existing shell
+# environment variables to be valid XML values
+#
+function sanitize_shell_env_vars_to_valid_xml_values() {
+  # Certain shell environment variables have a special function (e.g. HOSTNAME)
+  # Avoid their modification (XML escaping) by listing them as protected
+  declare -ra PROTECTED_SHELL_VARIABLES=(
+    # Base set of env vars as known to Red Hat UBI 8 Minimal container image,
+    # which need to be protected
+    "HOME" "HOSTNAME" "LANG" "OLDPWD" "PATH" "PWD" "SHLVL" "TERM" "_"
+    # nss_wrapper specific env vars, which need to be protected
+    "LD_PRELOAD" "NSS_WRAPPER_GROUP" "NSS_WRAPPER_PASSWD"
+    # EAP layer specific env vars, which need to be protected
+    "ADMIN_USERNAME" "ADMIN_PASSWORD"
+    "EAP_ADMIN_USERNAME" "EAP_ADMIN_PASSWORD"
+    "DEFAULT_ADMIN_USERNAME" # !DEFAULT_ADMIN_PASSWORD variable doesn't exist!
+    "SSO_USERNAME" "SSO_PASSWORD"
+    # RH-SSO layer specific env vars, which need to be protected
+    "SSO_ADMIN_USERNAME" "SSO_ADMIN_PASSWORD" "SSO_REALM"
+    "SSO_SERVICE_USERNAME" "SSO_SERVICE_PASSWORD"
+  )
+  # All shell variables present in RH-SSO container image without lowercase
+  # ones also ignoring alias definitions
+  declare -ra ALL_SHELL_VARIABLES=(
+    $(printenv | grep -P ^[A-Z_]+= | cut -d= -f1 | sort)
+  )
+  # For better code readability store Bash representation of apostrophe and
+  # double quote to local readonly variables for later use
+  # Bash apostrophe string is a single apostrophe enclosed with double quotes
+  local -r BASH_APOS="'"
+  # Bash double quote string is a single double quote enclosed with apostrophes
+  local -r BASH_QUOT='"'
+  # Modifiable environment variables (their values are safe to be XML escaped)
+  # are those from all environment variables which aren't protected
+  for var in "${ALL_SHELL_VARIABLES[@]}"
+  do
+    # Get the current (original) value of the environment variable
+    local ORIGINAL_VALUE=$(printenv "${var}")
+    if
+      # Variable isn't protected
+      ! grep -q "${var}" <<< "${PROTECTED_SHELL_VARIABLES[*]}" &&
+      # And its value contains at least one of the special XML characters
+      grep -Pq "(${BASH_APOS}|${BASH_QUOT}|&|<|>)" <<< "${ORIGINAL_VALUE}"
+    then
+      # XML escape the original value of the environment variable
+      local XML_ESCAPED_VALUE=$(escape_xml_characters "${ORIGINAL_VALUE}")
+      # Reset the value of the environment variable to the escaped form
+      # First explicitly undefine / remove the variable definition
+      if unset -v "${var}"
+      then
+        # Then export it to subshells with the escaped value again
+        export "${var}"="${XML_ESCAPED_VALUE}"
+      # If the attempt to remove the variable failed (e.g. because it is
+      # a readonly one), that's an unrecoverable error
+      else
+        echo "Failed to undefine the '${var}' environment variable."
+        exit 1
+      fi
+    fi
+  done
+}
+
+# RHSSO-2017 Escape characters interpolated when used within sed right-hand
+# side expression (namely '&' and ';' characters) with their actual literal
+# representation
+#
+# Per specific SED FAQ section:
+#
+#   http://sed.sourceforge.net/sedfaq3.html#s3.1.2
+#
+# the ampersand character is interpolated when used at right-hand side of a
+# sed substitute command expression (it is replaced by the entire
+# expression matched on the left-hand side). Thus to enter a literal
+# ampersand working also for sed on the right-hand side, we need to type a
+# '\&'.
+#
+# Moreover, the backslash (\) character itself needs to be escaped for Bash
+# with another backslash per relevant Bash guide section:
+#
+#  https://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting
+#
+# Thus to enter a literal ampersand working on the right-hand side of the
+# sed substitute command, called from Bash script, we need to type '\\&'.
+#
+function escape_sed_rhs_interpolated_characters() {
+  if [[ "$#" -eq "1" ]]
+  then
+    input="${1//&/\\&}"
+    input="${input//;/\\;}"
+    # Return the resulting string
+    echo "${input}"
+  else
+    echo "Please specify exactly one string to be escaped"
+    echo "for sed right-hand side expression."
+    exit 1
+  fi
+}
+
+### Script body
+
+# Important:
+# ----------
+#
+# RHSSO-2017 Since we want to escape the special XML characters (replace them
+# with their XML escape sequence counterparts) possibly present in the values
+# of selected environment variables (those that don't have a special meaning to
+# the shell itself) in both the current shell environment and also in the
+# subsequent child shell sessions, the
+# "sanitize_shell_env_vars_to_valid_xml_values()" function below is truly
+# intended to be executed RIGHT AWAY in the moment this script definition is
+# being Bash "source"d (included in another Bash script / module).
+#
+# Executing the function right away as part of the sourcing ensures also values
+# of the environment variables in the current shell will be sanitized (and via
+# export also propagated to subsequent child shells), see e.g.:
+#
+# * https://stackoverflow.com/a/28489593
+# * https://www.man7.org/linux/man-pages/man1/bash.1.html#SHELL_BUILTIN_COMMANDS
+#   (see the section dedicated to the 'source' directive)
+#
+# in contrary to the case when just the copy of the environment variable
+# accessible to the subshell, from which the function was called would be
+# updated
+#
+sanitize_shell_env_vars_to_valid_xml_values


### PR DESCRIPTION
Escape the [five characters requiring a special treatment in XML](https://www.ibm.com/docs/en/was-liberty/base?topic=manually-xml-escape-characters) into their corresponding XML escape sequences when specified as input in the value of some environment variable recognized by the image and subsequently propagated into the ```standalone-openshift.xml``` configuration file

Also, since each of the XML escape sequences contains the ampersand ```&``` and semicolon ```;``` characters again, and these two characters are interpolated when present in right-hand side expression on the ```sed``` command (which is internally used to produce the final form of the ```standalone-openshift.xml``` file), escape them too for both ```sed``` and ```Bash``` so they are treated literally (thus as plain ```&``` and ```;``` characters) rather than characters having a special meaning for ```sed``` when used in RHS expression. See a dedicated ```sed``` FAQ section:
* http://sed.sourceforge.net/sedfaq3.html#s3.1.2
and the correlated Bash quoting guide:
* https://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting
for further details why this additional escaping is necessary

**_Testing details:_**
- A candidate testing image built with the change is available at Quay repo under the Quay [RH-SSO CICD organization](https://recovery.quay.io/user/rh-sso-cicd)
```
$ docker / podman pull quay.io/rh-sso-cicd/sso75-openshift-rhel8-rhsso-2017:latest
```

**_To quickly locally test just any special characters in some randomly chosen env value:_**
(e.g. ```HTTPS_PASSWORD```, ```JGROUPS_ENCRYPT_PASSWORD```, or ```TRUSTSTORE_PASSWORD``` etc.) are properly escaped when expanded in ```standalone-openshift.xml``` configuration file (minimal reproducer), run something like (the associated JCEKS keystore file & secret might not even be a valid files. In that case the container will throw some error. But that doesn't matter for the purpose of
this minimal reproducer):

1. Create the pseudo-keystore & pseudo-secret:
```
$ mkdir -p /tmp/jgroups
$ touch /tmp/jgroups/{keystore.jceks,secret.jceks}
```
2. In one tty run the RH-SSO container with custom JGroups password containing special characters:
```
$ docker run -it -e JGROUPS_ENCRYPT_SECRET=/etc/jgroups/jgroups.secret -e JGROUPS_ENCRYPT_NAME=sso-secret -e JGROUPS_ENCRYPT_KEYSTORE=keystore.jceks -e JGROUPS_ENCRYPT_KEYSTORE_DIR=/etc/jgroups/keystore.jceks -e JGROUPS_ENCRYPT_PASSWORD=">>pass&&word<<" -v /tmp/jgroups:/etc/jgroups quay.io/rh-sso-cicd/sso75-openshift-rhel8-rhsso-2017:latest
```
3. In another tty check the form of the JGroups password as present in the produced ```standalone-openshift.xml``` configuration file:
```
$ docker exec -it eb17bef54042 grep 'clear-text' /opt/eap/standalone/configuration/standalone-openshift.xml
 <credential-reference clear-text="&gt;&gt;pass&amp;&amp;word&lt;&lt;"/>
                        <credential-reference clear-text="password"/>
                        <credential-reference clear-text="password"/>
       <key-credential-reference clear-text="&gt;&gt;pass&amp;&amp;word&lt;&lt;"/>
       <key-credential-reference clear-text="&gt;&gt;pass&amp;&amp;word&lt;&lt;"/>
```
As can be seen, the aforementioned ```JGROUPS_ENCRYPT_PASSWORD``` got properly escaped into XML form. In contrary
to that, running the same scenario with the latest RH-SSO 7.5.X image, returns the following error (it's visible right away in the container log & the image fails to start):
```
$ docker pull registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:latest
```
The complete log in the following command was shortened to list only interesting parts for brevity:
```
$ docker run -it -e JGROUPS_ENCRYPT_SECRET=/etc/jgroups/jgroups.secret -e JGROUPS_ENCRYPT_NAME=sso-secret -e JGROUPS_ENCRYPT_KEYSTORE=keystore.jceks -e JGROUPS_ENCRYPT_KEYSTORE_DIR=/etc/jgroups/keystore.jceks -e JGROUPS_ENCRYPT_PASSWORD=">>pass&&word<<" -v /tmp/jgroups:/etc/jgroups registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:latest
...
11:14:29,966 ERROR [org.jboss.as.controller] (Controller Boot Thread) 

OPVDX001: Validation error in standalone-openshift.xml -------------------------
|
|  350:            <key-stores>
|  351:                <key-store name="keystore.jceks">
|  352: <credential-reference clear-text=">>pass<!-- ##ELYTRON_KEY_STORE## --><!-- ##ELYTRON_KEY_STORE## -->word<<"/>
|                                               ^^^^ Unexpected character '<' (code 60) in attribute value
|
|  353: <implementation type="JCEKS"/>
|  354: <file path="/etc/jgroups/keystore.jceks/keystore.jceks" />
|  355: </key-store><!-- ##ELYTRON_KEY_STORE## -->
|
| The primary underlying error message was:
| > Unexpected character '<' (code 60) in attribute value
| >  at [row,col {unknown-source}]: [352,42]
|
|-------------------------------------------------------------------------------

11:14:29,967 ERROR [org.jboss.as.server] (Controller Boot Thread) WFLYSRV0055: Caught exception during boot: org.jboss.as.controller.persistence.ConfigurationPersistenceException: WFLYCTL0085: Failed to parse configuration
	at org.jboss.as.controller@15.0.8.Final-redhat-00001//org.jboss.as.controller.persistence.XmlConfigurationPersister.load(XmlConfigurationPersister.java:143)
	at org.jboss.as.server@15.0.8.Final-redhat-00001//org.jboss.as.server.ServerService.boot(ServerService.java:407)
	at org.jboss.as.controller@15.0.8.Final-redhat-00001//org.jboss.as.controller.AbstractControllerService$1.run(AbstractControllerService.java:416)
	at java.base/java.lang.Thread.run(Thread.java:829)

11:14:29,968 FATAL [org.jboss.as.server] (Controller Boot Thread) WFLYSRV0056: Server boot has failed in an unrecoverable manner; exiting. See previous messages for details.
11:14:29,988 INFO  [org.jboss.as] (MSC service thread 1-2) WFLYSRV0050: WildFly Core 15.0.8.Final-redhat-00001 stopped in 6ms
```
**_Full (a more complete) testing scenario (on OpenShift):_**
(checking the value is escaped, the associated keystore can be properly loaded, the log doesn't contain error above etc.)

To be part of the upcoming / WIP ```com.redhat.xpaas.sso.template.XMLEscapeCharactersTest``` XPaaS QE test suite.

@Pepo48 @ikhomyn PTAL once got a chance (a more detailed scenario on how this can be tested to come)

@drichtarik @ASzc @pskopek jFYI

Thanks,
Jan
