### PR TITLE
[RHSSO-2180] Provide explicit URLs to txn-recovery-marker-jdbc-common & txn-recovery-marker-jdbc-hibernate5

### DIFF
--- a/modules/eap/setup/eap/modules/module.yaml
+++ b/modules/eap/setup/eap/modules/module.yaml
@@ -40,9 +40,11 @@ artifacts:
 - name: txn-recovery-marker-jdbc-common
   target: txn-recovery-marker-jdbc-common-1.1.4.Final-redhat-00001.jar
   md5: 305aa706018b1089e5b82528b601541f
+  url: http://$DOWNLOAD_SERVER/brewroot/packages/io.narayana-narayana-openshift-tools-parent/1.1.4.Final_redhat_00001/1/maven/io/narayana/txn-recovery-marker-jdbc-common/1.1.4.Final-redhat-00001/txn-recovery-marker-jdbc-common-1.1.4.Final-redhat-00001.jar
 - name: txn-recovery-marker-jdbc-hibernate5
   target: txn-recovery-marker-jdbc-hibernate5-1.1.4.Final-redhat-00001.jar
   md5: 99f2a2e68fb92273b8016e2b199fbd91
+  url: http://$DOWNLOAD_SERVER/brewroot/packages/io.narayana-narayana-openshift-tools-parent/1.1.4.Final_redhat_00001/1/maven/io/narayana/txn-recovery-marker-jdbc-hibernate5/1.1.4.Final-redhat-00001/txn-recovery-marker-jdbc-hibernate5-1.1.4.Final-redhat-00001.jar
 
 # The following three Wildfly Galleon plug-in related artifacts are required
 # for a successful OSBS build.


### PR DESCRIPTION
    [RHSSO-2180] Since per Python's Zen's PEP 20 rule
    "Explicit is better than implicit" provide explicit URLs to:
    
    * txn-recovery-marker-jdbc-common-1.1.4.Final-redhat-00001.jar
    * txn-recovery-marker-jdbc-hibernate5-1.1.4.Final-redhat-00001.jar
    
    artifacts (to avoid possible CEKit's failure to locate/fetch them)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

--
[PEP 20 rules](https://peps.python.org/pep-0020/)

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
