### PR TITLE
[RHSSO-1981] Update  RH-SSO server version to 7.5.3.GA & EAP server version to 7.4.6.GA

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -12,7 +12,7 @@ labels:
     - name: "org.jboss.product"
       value: &product "sso"
     - name: "org.jboss.product.version"
-      value: &product_version "7.5.2.GA"
+      value: &product_version "7.5.3.GA"
     - name: "org.jboss.product.sso.version"
       value: *product_version
     - name: "io.k8s.description"
@@ -73,22 +73,22 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.45.3
+                  ref: 0.45.4
 
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_744_CR2
+                  ref: EAP_746_CR2_3
 
           - name: jboss-eap-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_744_CR2
+                  ref: EAP_LP_746_CR1
 
           - name: wildfly-cekit-modules
             git:
                   url: https://github.com/wildfly/wildfly-cekit-modules.git
-                  ref: 0.23.4
+                  ref: 0.23.8
 
           - name: sso-modules
             path: modules

--- a/modules/eap/setup/eap/modules/module.yaml
+++ b/modules/eap/setup/eap/modules/module.yaml
@@ -31,11 +31,11 @@ ports:
 artifacts:
 - name: eap-image-maven-repo
   target: maven-repo.zip
-  md5: f09134d49bcee9a583ec3d2d9402f8c2
-  url: http://$DOWNLOAD_SERVER/released/middleware/eap7/7.4.4/jboss-eap-7.4.4-image-builder-maven-repository.zip
-# RHSSO-1824: Update RH-SSO server overlay to 'RH-SSO 7.5.2.CR1' build
+  md5: 3630967f24b62c537fa3fa7b1d25232d
+  url: http://$DOWNLOAD_SERVER/released/jboss/eap7/7.4.6/jboss-eap-7.4.6-image-builder-maven-repository.zip
+# RHSSO-1824: Update RH-SSO server overlay to 'RH-SSO 7.5.3.CR2' build
 - name: keycloak-server-overlay.zip
-  md5: 7ea126bb6d903c88727fa3636150c63a
+  md5: 275620f9b71aed491819f0b29ca12495
 # List remaining (particular RH-SSO build independent) artifacts below
 - name: txn-recovery-marker-jdbc-common
   target: txn-recovery-marker-jdbc-common-1.1.4.Final-redhat-00001.jar
@@ -58,53 +58,59 @@ artifacts:
 #       accordingly in the 'modules/eap/setup/eap/modules/configure.sh'
 #       script too !!!
 #
-- name: wildfly-galleon-maven-plugin-5.1.2.Final-redhat-00001.jar
-  pnc_build_id: ARNYWZY2QGAAA
-  pnc_artifact_id: "8065279"
-  target: wildfly-galleon-maven-plugin-5.1.2.Final.jar
-- name: wildfly-galleon-maven-plugin-5.1.2.Final-redhat-00001.pom
-  pnc_build_id: ARNYWZY2QGAAA
-  pnc_artifact_id: "8065283"
-  target: wildfly-galleon-maven-plugin-5.1.2.Final.pom
-- name: wildfly-provisioning-parent-5.1.2.Final-redhat-00001.pom
-  pnc_build_id: ARNYWZY2QGAAA
-  pnc_artifact_id: "8065285"
-  target: wildfly-provisioning-parent-5.1.2.Final.pom
+- name: wildfly-galleon-maven-plugin-5.2.6.Final-redhat-00001.pom
+  pnc_build_id: ATUBRXXNDVQAA
+  pnc_artifact_id: "8706028"
+  target: wildfly-galleon-maven-plugin-5.2.6.Final.pom
+- name: wildfly-galleon-maven-plugin-5.2.6.Final-redhat-00001.jar
+  pnc_build_id: ATUBRXXNDVQAA
+  pnc_artifact_id: "8706035"
+  target: wildfly-galleon-maven-plugin-5.2.6.Final.jar
+- name: wildfly-provisioning-parent-5.2.6.Final-redhat-00001.pom
+  pnc_build_id: ATUBRXXNDVQAA
+  pnc_artifact_id: "8706024"
+  target: wildfly-provisioning-parent-5.2.6.Final.pom
 labels:
 - name: "org.jboss.product"
   value: "eap"
 - name: "org.jboss.product.version"
-  value: "7.4.4"
+  value: "7.4.6"
 - name: "org.jboss.product.eap.version"
-  value: "7.4.4"
+  value: "7.4.6"
+- name: "org.jboss.product.openjdk.version"
+  value: "11"
 - name: "com.redhat.deployments-dir"
   value: "/opt/eap/standalone/deployments"
 - name: "com.redhat.dev-mode"
   value: "DEBUG:true"
 - name: "com.redhat.dev-mode.port"
   value: "DEBUG_PORT:8787"
-- name: io.fabric8.s2i.version.maven
+- name: "com.redhat.license_terms"
+  value: "https://www.redhat.com/agreements"
+- name: "io.fabric8.s2i.version.maven"
   value: "3.6"
-- name: io.fabric8.s2i.version.jolokia
-  value: "1.6.2-redhat-00002"
+- name: "io.openshift.expose-services"
+  value: "8080:http"
+- name: "io.fabric8.s2i.version.jolokia"
+  value: "1.7.1.redhat-00001"
 - name: "io.openshift.s2i.scripts-url"
   value: "image:///usr/local/s2i"
-- name: io.openshift.s2i.destination
+- name: "io.openshift.s2i.destination"
   value: "/tmp"
-- name: org.jboss.container.deployments-dir
+- name: "org.jboss.container.deployments-dir"
   value: "/deployments"
 envs:
 - name: "WILDFLY_VERSION"
   description: "Mandatory. WildFly server version."
-  value: "7.4.4.GA-redhat-00011"
+  value: "7.4.6.GA-redhat-00002"
 - name: "LAUNCH_JBOSS_IN_BACKGROUND"
   value: "true"
 - name: "JBOSS_PRODUCT"
   value: "eap"
 - name: "JBOSS_EAP_VERSION"
-  value: "7.4.4"
+  value: "7.4.6"
 - name: "PRODUCT_VERSION"
-  value: "7.4.4"
+  value: "7.4.6"
 - name: "EAP_FULL_GROUPID"
   value: "org.jboss.eap"
 - name: "JBOSS_HOME"
@@ -120,7 +126,7 @@ envs:
 - name: MAVEN_VERSION
   value: "3.6"
 - name: JOLOKIA_VERSION
-  value: "1.6.2"
+  value: "1.7.1"
 - name: AB_JOLOKIA_PASSWORD_RANDOM
   value: "true"
 - name: AB_JOLOKIA_AUTH_OPENSHIFT
@@ -244,7 +250,7 @@ envs:
   description: ^
     Space separated list of filters to be applied when copying deployments.
     Defaults to ** * **
-  value: "*"
+  value: "*.war *.ear *.rar *.jar"
   example: "*.jar *.war *.ear"
 - name: S2I_TARGET_DEPLOYMENTS_DIR
   description: ^
@@ -371,9 +377,6 @@ envs:
   value: /opt/jboss/container/wildfly/s2i
 - name: JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_PROVISION
   value: /opt/jboss/container/wildfly/s2i/galleon/provisioning/generic_provisioning
-- name: GALLEON_DEFINITIONS
-- name: S2I_SOURCE_DEPLOYMENTS_FILTER
-  value: "*.war *.ear *.rar *.jar"
 - name: WILDFLY_S2I_OUTPUT_DIR
   value: "/s2i-output"
 - name: JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR
@@ -390,7 +393,7 @@ envs:
 - name: GALLEON_MAVEN_BUILD_IMG_SETTINGS_XML
   value: /opt/jboss/container/wildfly/s2i/galleon/build-image-settings.xml
 - name: GALLEON_MAVEN_REPO_HOOK_SCRIPT
-- name: GALLEON_S2I_FP_GROUP_ID
+  value: /opt/jboss/container/eap/galleon/patching.sh
 - name: GALLEON_S2I_FP_ARTIFACT_ID
 - name: GALLEON_VERSION
   value: "4.2.8.Final"
@@ -401,12 +404,9 @@ envs:
 #   artifacts listed in the 'artifacts:' section above
 #
 - name: GALLEON_WILDFLY_VERSION
-  value: "5.1.2.Final"
-- name: GALLEON_S2I_PRODUCER_NAME
-- name: S2I_FP_VERSION
+  value: "5.2.6.Final"
 - name: GALLEON_PROVISION_SERVER
 - name: GALLEON_PROVISION_LAYERS
-- name: GALLEON_DEFAULT_FAT_SERVER
 - name: GALLEON_PROVISION_DEFAULT_FAT_SERVER
 - name: S2I_COPY_SERVER
   value: "true"

--- a/modules/sso/apply/patches/module.yaml
+++ b/modules/sso/apply/patches/module.yaml
@@ -4,12 +4,6 @@ version: '1.0'
 description: Module to apply any possibly needed EAP / RH-SSO one-off patches via jboss-cli.sh
 execute:
 - script: apply-eap-rh-sso-one-off-patches.sh
-artifacts:
-## CIAM-2657
-- md5: 0925d9b712d75e1d12f8efa40bcc54ca
-  name: rhsso-2657.zip
-  target: rhsso-2657.zip
-  url: http://$DOWNLOAD_SERVER/released/JBoss-middleware/sso/7.5.2/patches/rhsso-2657.zip
 
 # Note:
 #

--- a/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
+++ b/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
@@ -12,7 +12,6 @@ function postConfigure() {
   verify_CIAM_1757_fix_present
   #verify_CIAM_1975_fix_present
   #verify_CIAM_2055_fix_present
-  verify_CIAM_2657_fix_present
 }
 
 # KEYCLOAK-13585 / RH BZ#1817530 / CVE-2020-10695:
@@ -102,16 +101,6 @@ function verify_CIAM_2055_fix_present() {
   if ! find "${JBOSS_HOME}"/modules/system/layers -name '*-rhsso-2054.jar' 2> /dev/null | grep -q .
   then
     log_error "The CIAM-2055 one-off patch wasn't properly installed."
-    log_error "Cannot start the '${JBOSS_IMAGE_NAME}', version '${JBOSS_IMAGE_VERSION}'!"
-    exit "${errorExitCode}"
-  fi
-}
-
-function verify_CIAM_2657_fix_present() {
-  local -r errorExitCode="1"
-  if ! find "${JBOSS_HOME}"/modules/system/layers -name '*-rhsso-2657.jar' 2> /dev/null | grep -q .
-  then
-    log_error "The CIAM-2657 one-off patch wasn't properly installed."
     log_error "Cannot start the '${JBOSS_IMAGE_NAME}', version '${JBOSS_IMAGE_VERSION}'!"
     exit "${errorExitCode}"
   fi

--- a/templates/sso75-https.json
+++ b/templates/sso75-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.5.2.GA",
+            "version": "7.5.3.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.5 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso75-dev/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso75-https",
-        "rhsso": "7.5.2.GA"
+        "rhsso": "7.5.3.GA"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso75-image-stream.json
+++ b/templates/sso75-image-stream.json
@@ -56,11 +56,11 @@
                     "description": "Red Hat Single Sign-On 7.5 on OpenJDK",
                     "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.5.2.GA"
+                    "version": "7.5.3.GA"
                 }
             },
             "labels": {
-                "rhsso": "7.5.2.GA"
+                "rhsso": "7.5.3.GA"
             },
             "spec": {
                 "tags": [

--- a/templates/sso75-ocp4-x509-https.json
+++ b/templates/sso75-ocp4-x509-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.5.2.GA",
+            "version": "7.5.3.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.5 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso75-dev/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso75-ocp4-x509-https",
-        "rhsso": "7.5.2.GA"
+        "rhsso": "7.5.3.GA"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso75-ocp4-x509-postgresql-persistent.json
+++ b/templates/sso75-ocp4-x509-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.5.2.GA",
+            "version": "7.5.3.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK + PostgreSQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.5 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso75-dev/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso75-ocp4-x509-postgresql-persistent",
-        "rhsso": "7.5.2.GA"
+        "rhsso": "7.5.3.GA"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso75-postgresql-persistent.json
+++ b/templates/sso75-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.5.2.GA",
+            "version": "7.5.3.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK + PostgreSQL (Persistent with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.5 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso75-dev/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso75-postgresql-persistent",
-        "rhsso": "7.5.2.GA"
+        "rhsso": "7.5.3.GA"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso75-postgresql.json
+++ b/templates/sso75-postgresql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss,hidden",
-            "version": "7.5.2.GA",
+            "version": "7.5.3.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK + PostgreSQL (Ephemeral with passthrough TLS)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.5 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso75-dev/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso75-postgresql",
-        "rhsso": "7.5.2.GA"
+        "rhsso": "7.5.3.GA"
     },
     "message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "parameters": [

--- a/templates/sso75-x509-https.json
+++ b/templates/sso75-x509-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.5.2.GA",
+            "version": "7.5.3.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.5 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso75-dev/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso75-x509-https",
-        "rhsso": "7.5.2.GA"
+        "rhsso": "7.5.3.GA"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [

--- a/templates/sso75-x509-postgresql-persistent.json
+++ b/templates/sso75-x509-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass" : "icon-sso",
             "tags" : "sso,keycloak,jboss",
-            "version": "7.5.2.GA",
+            "version": "7.5.3.GA",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK + PostgreSQL SSL/TLS (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example application based on RH-SSO 7.5 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso75-dev/docs.",
@@ -17,7 +17,7 @@
     },
     "labels": {
         "template": "sso75-x509-postgresql-persistent",
-        "rhsso": "7.5.2.GA"
+        "rhsso": "7.5.3.GA"
     },
     "message": "A new persistent RH-SSO service (using SSL/TLS secured PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, the server truststore used for securing RH-SSO requests, and SSL/TLS certificate & private key used to run PostgreSQL server with SSL/TLS support were automatically created via OpenShift's service serving x509 certificate secrets.",
     "parameters": [


### PR DESCRIPTION
    [RHSSO-1981] Update:
    
    * RH-SSO server version to 7.5.3.GA,
    * EAP server version to 7.4.6.GA,
    * Wildfly Galleon plugin & Wildfly Galleon provisioning parent
      version to 5.2.6,
    * Templates version to 7.5.3.GA
    
    Also sync various labels and env vars to the values as present in the
    EAP 7.4 with OpenJDK 11 for OpenShift container image
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Testing: A candidate RH-SSO container image containing this change was built within \#587 container pipeline run.


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
