### PR TITLE
[RHSSO-2191] Define the AUS env var at YAML level, so its available for all subsequent CCT modules using it

### DIFF
--- a/modules/sso/rcfile/module.yaml
+++ b/modules/sso/rcfile/module.yaml
@@ -1,9 +1,36 @@
 schema_version: 1
 name: sso.rcfile
 version: '1.0'
-description: >
-  Defines RH-SSO global variables & functions required by subsequent image modules.
+description: ^
+  Defines RH-SSO global variables & functions required by subsequent image
+  modules.
 envs:
+# CIAM-1394 Use a non-printable character - ASCII 31 (octal 037) unit
+# separator character as the sed substitute (s) command delimiter for each
+# existing call of "sed -i" and "sed -e" across the various container image
+# modules, where either the regexp or the replacement value is dynamically
+# generated (IOW it's not a fixed string) and it's based on / derived from
+# the value of some environment variable.
+#
+# Do this to avoid clash of the sed substitute command delimiter with some
+# special character specified in env var value (e.g. in password), leading to:
+#
+# * sed: -e expression #1, char <CHAR_POS>: unterminated `s' command
+# * sed: -e expression #1, char <CHAR_POS>: unknown option to 's'
+#
+# type of errors
+- name: "AUS"
+  # Since the notation of octal numbers changed in YAML specification between
+  # v1.1 (using the '0777' notation) vs v1.2 (using the '0o777' notation), we
+  # express the AUS value using the hexadecimal notation, which is same and
+  # works across all YAML spec versions.
+  value: "\x1f"
+  description: ^
+    A **single** **control** character used as the delimiter within any sed 's'
+    command executed throughout the run of the RH-SSO container image. In
+    ASCII, the control characters have octal codes 000 through 037, and 177
+    (DEL). Defaults to the ASCII Unit Separator (US) character, the '1F' value
+    in hex notation.
 - name: "JBOSS_HOME"
   value: "/opt/eap"
 execute:

--- a/modules/sso/rcfile/sso-rcfile-definitions.sh
+++ b/modules/sso/rcfile/sso-rcfile-definitions.sh
@@ -8,23 +8,13 @@ set -e
 
 
 ### RH-SSO globally used variables
-
-# CIAM-1394 Use a non-printable character - ASCII 31 (octal 037) unit
-# separator character as the sed substitute (s) command delimiter for each
-# existing call of "sed -i" and "sed -e" across the various container image
-# modules, where either the regexp or the replacement value is dynamically
-# generated (IOW it's not a fixed string) and it's based on / derived from
-# the value of some environment variable.
 #
-# Do this to avoid clash of the sed substitute command delimiter with some
-# special character specified in env var value (e.g. in password), leading to:
-#
-# * sed: -e expression #1, char <CHAR_POS>: unterminated `s' command
-# * sed: -e expression #1, char <CHAR_POS>: unknown option to 's'
-#
-# type of errors
-# shellcheck disable=SC2034
-export readonly AUS=$'\037'
+# NOTE: Shell variables intended to be global should be defined at YAML level
+#       rather than in this place. Using their YAML level definition ensures
+#       they are defined regardless of the way the Bash script of a particular
+#       CCT module is executed (interactive vs non-interactive mode) and they
+#       are defined also regardless of the user ID, which is used to run the
+#       Bash script of a particular CCT module
 
 ### RH-SSO globally used functions
 
@@ -68,8 +58,10 @@ function escape_xml_characters() {
 #
 function sanitize_shell_env_vars_to_valid_xml_values() {
   # Certain shell environment variables have a special function (e.g. HOSTNAME)
-  # Avoid their modification (XML escaping) by listing them as protected
+  # Avoid their modification (XML escaping) by enumerating them as protected
   declare -ra PROTECTED_SHELL_VARIABLES=(
+    # A single control character used as the sed 's' command delimiter
+    "AUS"
     # Base set of env vars as known to Red Hat UBI 8 Minimal container image,
     # which need to be protected
     "HOME" "HOSTNAME" "LANG" "OLDPWD" "PATH" "PWD" "SHLVL" "TERM" "_"

--- a/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
+++ b/modules/sso/sso-pre-launch-checks/added/sso_image_pre_launch_checks.sh
@@ -7,11 +7,48 @@ set -e
 source "${JBOSS_HOME}/bin/launch/logging.sh"
 
 function postConfigure() {
+  verify_correct_definition_of_sed_delimiter_character
   verify_CVE_2020_10695_fix_present
   verify_KEYCLOAK_16736_fix_present
   verify_CIAM_1757_fix_present
   #verify_CIAM_1975_fix_present
   #verify_CIAM_2055_fix_present
+}
+
+# RHSSO-2191
+#
+# Verify the AUS env var, used as the sed delimiter character in any sed 's'
+# command:
+#
+# 1) Is defined (is not an empty string),
+# 2) Is a control character (octal 000 through 037, or the DEL character),
+#    not to clash with any other printable character, possibly present in
+#    sed regex/replacement,
+# 3) Is it a single character (since sed supports only single-byte characters
+#    as delimiters)
+#
+function verify_correct_definition_of_sed_delimiter_character() {
+  local -r errorExitCode="1"
+  # Is AUS env var defined and not empty?
+  # NOTE: The -v test checks the name of the env var, not its value,
+  #       so we intentionally don't use the dollar sign in the next statement.
+  if ! [[ -v AUS ]]
+  then
+    log_error "The AUS environment variable is not set or is empty string."
+    log_error "Please define it as it is used as the delimiter character for the sed 's' command."
+    exit "${errorExitCode}"
+  # Is AUS a control char?
+  elif ! [[ "${AUS}" =~ [[:cntrl:]] ]]
+  then
+    log_error "Only control character (octal codes 000 through 037, and 177)"
+    log_error "can be used as the delimiter character for the sed 's' command."
+    exit "${errorExitCode}"
+  # Is AUS a single character?
+  elif [[ "${#AUS}" -ne "1" ]]
+  then
+    log_error "Only a single-byte character can be used as the delimiter for the sed 's' command."
+    exit "${errorExitCode}"
+  fi
 }
 
 # KEYCLOAK-13585 / RH BZ#1817530 / CVE-2020-10695:


### PR DESCRIPTION
    [RHSSO-2191] Ensure the AUS env var (used to defined the delimiter
    character used across all sed 's' commands) is:
    
    * Defined & not empty string,
    * Set to some ASCII control character (octal codes 000 through 037,
      or 177),
    * Set to a single character (since only single-byte character can be
      used as the sed delimiter based on the way sed is compiled on RHEL)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
