### PR TITLE
[RHSSO-2203] Ensure expiry works in Infinispan

### DIFF
--- a/modules/sso/config/launch/setup/76/added/standalone-openshift.xml
+++ b/modules/sso/config/launch/setup/76/added/standalone-openshift.xml
@@ -375,23 +375,37 @@
                 <local-cache name="users">
                     <heap-memory size="10000"/>
                 </local-cache>
-                <distributed-cache name="sessions" owners="${env.CACHE_OWNERS_COUNT:1}"/>
-                <distributed-cache name="authenticationSessions" owners="${env.CACHE_OWNERS_AUTH_SESSIONS_COUNT:1}"/>
-                <distributed-cache name="offlineSessions" owners="${env.CACHE_OWNERS_COUNT:1}"/>
-                <distributed-cache name="clientSessions" owners="${env.CACHE_OWNERS_COUNT:1}"/>
-                <distributed-cache name="offlineClientSessions" owners="${env.CACHE_OWNERS_COUNT:1}"/>
-                <distributed-cache name="loginFailures" owners="${env.CACHE_OWNERS_COUNT:1}"/>
+                <distributed-cache name="sessions" owners="${env.CACHE_OWNERS_COUNT:1}">
+                    <expiration lifespan="900000000000000000"/>
+                </distributed-cache>
+                <distributed-cache name="authenticationSessions" owners="${env.CACHE_OWNERS_AUTH_SESSIONS_COUNT:1}">
+                    <expiration lifespan="900000000000000000"/>
+                </distributed-cache>
+                <distributed-cache name="offlineSessions" owners="${env.CACHE_OWNERS_COUNT:1}">
+                    <expiration lifespan="900000000000000000"/>
+                </distributed-cache>
+                <distributed-cache name="clientSessions" owners="${env.CACHE_OWNERS_COUNT:1}">
+                    <expiration lifespan="900000000000000000"/>
+                </distributed-cache>
+                <distributed-cache name="offlineClientSessions" owners="${env.CACHE_OWNERS_COUNT:1}">
+                    <expiration lifespan="900000000000000000"/>
+                </distributed-cache>
+                <distributed-cache name="loginFailures" owners="${env.CACHE_OWNERS_COUNT:1}">
+                    <expiration lifespan="900000000000000000"/>
+                </distributed-cache>
                 <local-cache name="authorization">
                     <heap-memory size="10000"/>
                 </local-cache>
-                <replicated-cache name="work"/>
+                <replicated-cache name="work">
+                    <expiration lifespan="900000000000000000"/>
+                </replicated-cache>
                 <local-cache name="keys">
                     <heap-memory size="1000"/>
                     <expiration max-idle="3600000"/>
                 </local-cache>
                 <distributed-cache name="actionTokens" owners="${env.CACHE_OWNERS_COUNT:2}">
                     <heap-memory size="-1"/>
-                    <expiration max-idle="-1" interval="300000"/>
+                    <expiration max-idle="-1" lifespan="900000000000000000" interval="300000"/>
                 </distributed-cache>
             </cache-container>
             <cache-container name="ejb" default-cache="repl" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">


### PR DESCRIPTION
Note: Same logic PR like in the case of RHSSO-1937, but applied against RH-SSO 7.6.X image this time

    [RHSSO-2203] Ensure expiry works in Infinispan
    
    Setting any lifespan will enable the Infinispan reaper process to remove expired entries. This avoids an OOM situation.
    
    Signed-off-by: Alexander Schwartz <aschwart@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
