### PR TITLE
[RHSSO-2211] [RHSSO-2191] Fix the failing S2I builds

### DIFF
--- a/modules/eap/setup/eap/modules/added/https.sh
+++ b/modules/eap/setup/eap/modules/added/https.sh
@@ -3,6 +3,9 @@
 
 source $JBOSS_HOME/bin/launch/logging.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function prepareEnv() {
   unset HTTPS_NAME
   unset HTTPS_PASSWORD

--- a/modules/eap/setup/eap/modules/added/keycloak.sh
+++ b/modules/eap/setup/eap/modules/added/keycloak.sh
@@ -2,6 +2,9 @@
 
 source $JBOSS_HOME/bin/launch/logging.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function prepareEnv() {
   unset APPLICATION_NAME
   unset APPLICATION_ROUTES

--- a/modules/eap/setup/eap/modules/added/launch/access_log_valve.sh
+++ b/modules/eap/setup/eap/modules/added/launch/access_log_valve.sh
@@ -31,6 +31,9 @@
 
 source $JBOSS_HOME/bin/launch/logging.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function configure() {
   configure_access_log_valve
   configure_access_log_handler

--- a/modules/eap/setup/eap/modules/added/launch/datasource-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/datasource-common.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 if [ -n "${TEST_LAUNCH_INCLUDE}" ]; then
     source "${TEST_LAUNCH_INCLUDE}"
 else

--- a/modules/eap/setup/eap/modules/added/launch/datasource.sh
+++ b/modules/eap/setup/eap/modules/added/launch/datasource.sh
@@ -2,6 +2,9 @@
 
 source $JBOSS_HOME/bin/launch/datasource-common.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function preConfigure() {
   # Since inject_datasources_common ends up executing in a sub-shell for where I want
   # to grab the value, use temp files to store what was used

--- a/modules/eap/setup/eap/modules/added/launch/deploymentScanner.sh
+++ b/modules/eap/setup/eap/modules/added/launch/deploymentScanner.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function configure() {
   configure_deployment_scanner
 }

--- a/modules/eap/setup/eap/modules/added/launch/elytron.sh
+++ b/modules/eap/setup/eap/modules/added/launch/elytron.sh
@@ -1,3 +1,7 @@
+
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 # only processes a single environment as the placeholder is not preserved
 prepareEnv() {
 

--- a/modules/eap/setup/eap/modules/added/launch/ha.sh
+++ b/modules/eap/setup/eap/modules/added/launch/ha.sh
@@ -2,6 +2,9 @@
 
 source $JBOSS_HOME/bin/launch/jgroups_common.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 prepareEnv() {
   unset OPENSHIFT_KUBE_PING_NAMESPACE
   unset OPENSHIFT_KUBE_PING_LABELS

--- a/modules/eap/setup/eap/modules/added/launch/jgroups.sh
+++ b/modules/eap/setup/eap/modules/added/launch/jgroups.sh
@@ -2,6 +2,9 @@
 
 source $JBOSS_HOME/bin/launch/jgroups_common.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 preConfigure() {
   init_protocol_list_store
 }

--- a/modules/eap/setup/eap/modules/added/launch/login-modules-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/login-modules-common.sh
@@ -2,6 +2,9 @@
 
 source $JBOSS_HOME/bin/launch/launch-common.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 # Arguments:
 # $1 - code
 # $2 - flag

--- a/modules/eap/setup/eap/modules/added/launch/management-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/management-common.sh
@@ -2,6 +2,9 @@
 
 source $JBOSS_HOME/bin/launch/launch-common.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 # Arguments:
 # $1 - realm
 function add_management_interface_realm() {

--- a/modules/eap/setup/eap/modules/added/launch/ports.sh
+++ b/modules/eap/setup/eap/modules/added/launch/ports.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # only processes a single environment as the placeholder is not preserved
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function prepareEnv() {
   unset PORT_OFFSET
 }

--- a/modules/eap/setup/eap/modules/added/launch/resource-adapters-common.sh
+++ b/modules/eap/setup/eap/modules/added/launch/resource-adapters-common.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function clearResourceAdapterEnv() {
   local prefix=$1
 

--- a/modules/eap/setup/eap/modules/added/launch/security-domains.sh
+++ b/modules/eap/setup/eap/modules/added/launch/security-domains.sh
@@ -1,4 +1,7 @@
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function prepareEnv() {
   unset SECDOMAIN_NAME
   unset SECDOMAIN_USERS_PROPERTIES

--- a/modules/eap/setup/eap/modules/added/launch/tx-datasource.sh
+++ b/modules/eap/setup/eap/modules/added/launch/tx-datasource.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 # Openshift EAP launch script datasource generation routines
 
 if [ -f $JBOSS_HOME/bin/launch/launch-common.sh ]; then

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/eap/galleon/patching.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/eap/galleon/patching.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 mavenRepo="$1"
 if [ -f "$mavenRepo/patches.xml" ]; then
   echo "The maven repository has been patched, setting patches in galleon feature-pack."

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/maven.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/maven/default/maven.sh
@@ -1,6 +1,9 @@
 # common shell routines for use with maven
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 # default settings.xml file
 __JBOSS_MAVEN_DEFAULT_SETTINGS_FILE="${HOME}/.m2/settings.xml"
 

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/galleon/s2i_galleon
@@ -1,3 +1,7 @@
+
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 GALLEON_GENERIC_LAYERS_DEFINITION="$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR"/provisioning/generic_layers
 GALLEON_EXTEND_CONFIG_DEFINITION="$JBOSS_CONTAINER_WILDFLY_S2I_GALLEON_DIR"/provisioning/extend_config
 

--- a/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
+++ b/modules/eap/setup/eap/modules/artifacts/opt/jboss/container/wildfly/s2i/install-common/install-common.sh
@@ -12,6 +12,8 @@ DEPLOY_DIR=$JBOSS_HOME/standalone/deployments
 
 source ${JBOSS_HOME}/bin/launch/openshift-common.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
 
 function find_env() {
   var=${!1}

--- a/modules/sso/config/launch/setup/76/added/launch/datasource.sh
+++ b/modules/sso/config/launch/setup/76/added/launch/datasource.sh
@@ -1,4 +1,8 @@
+
 source $JBOSS_HOME/bin/launch/datasource-common.sh
+
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
 
 function prepareEnv() {
   clearDatasourcesEnv

--- a/modules/sso/config/launch/setup/76/added/launch/keycloak-spi.sh
+++ b/modules/sso/config/launch/setup/76/added/launch/keycloak-spi.sh
@@ -3,6 +3,9 @@
 # Import logging module
 source $JBOSS_HOME/bin/launch/logging.sh
 
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
 function prepareEnv() {
   unset SSO_TRUSTSTORE
   unset SSO_TRUSTSTORE_DIR

--- a/modules/sso/config/launch/setup/76/added/launch/openshift-common.sh
+++ b/modules/sso/config/launch/setup/76/added/launch/openshift-common.sh
@@ -6,6 +6,15 @@ if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
 fi
 
+# RHSSO-2211 Import common EAP launch routines
+source "${JBOSS_HOME}/bin/launch/launch-common.sh"
+# RHSSO-2211 Import common RH-SSO global variables & functions
+source "${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh"
+
+# Escape XML special characters possibly present in values of
+# selected environment variables with their XML entity counterparts
+sanitize_shell_env_vars_to_valid_xml_values
+
 export CONFIG_FILE="${JBOSS_HOME}/standalone/configuration/standalone-openshift.xml"
 export LOGGING_FILE="${JBOSS_HOME}/standalone/configuration/logging.properties"
 

--- a/modules/sso/config/launch/setup/76/added/openshift-launch.sh
+++ b/modules/sso/config/launch/setup/76/added/openshift-launch.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 # Openshift EAP launch script
 
-# Import RH-SSO global variables & functions to container run-time
-source ${JBOSS_HOME}/bin/launch/sso-rcfile-definitions.sh
-# Other imports
+# Import the necessary Bash modules
 source ${JBOSS_HOME}/bin/launch/openshift-common.sh
 source $JBOSS_HOME/bin/launch/logging.sh
 

--- a/modules/sso/rcfile/sso-rcfile-definitions.sh
+++ b/modules/sso/rcfile/sso-rcfile-definitions.sh
@@ -160,31 +160,3 @@ function escape_sed_rhs_interpolated_characters() {
     exit 1
   fi
 }
-
-### Script body
-
-# Important:
-# ----------
-#
-# RHSSO-2017 Since we want to escape the special XML characters (replace them
-# with their XML escape sequence counterparts) possibly present in the values
-# of selected environment variables (those that don't have a special meaning to
-# the shell itself) in both the current shell environment and also in the
-# subsequent child shell sessions, the
-# "sanitize_shell_env_vars_to_valid_xml_values()" function below is truly
-# intended to be executed RIGHT AWAY in the moment this script definition is
-# being Bash "source"d (included in another Bash script / module).
-#
-# Executing the function right away as part of the sourcing ensures also values
-# of the environment variables in the current shell will be sanitized (and via
-# export also propagated to subsequent child shells), see e.g.:
-#
-# * https://stackoverflow.com/a/28489593
-# * https://www.man7.org/linux/man-pages/man1/bash.1.html#SHELL_BUILTIN_COMMANDS
-#   (see the section dedicated to the 'source' directive)
-#
-# in contrary to the case when just the copy of the environment variable
-# accessible to the subshell, from which the function was called would be
-# updated
-#
-sanitize_shell_env_vars_to_valid_xml_values


### PR DESCRIPTION
    [RHSSO-2211] [RHSSO-2191] Fix the failing S2I builds, erroring out due
    to the expected RH-SSO global env vars and global functions not being
    defined at the Maven S2I phase yet
    
    Also apply the same protective countermeasures to the functionality /
    those areas of the RH-SSO container image, utilizing the same (possibly
    undefined) global env vars and functions
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

**Testing:**

- RH-SSO container candidate image is available as part of the \#608 pipeline build
- An automated ```com.redhat.xpaas.sso.s2i.CustomJdbcDriverTest``` test was created to cover the testing

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
