### PR TITLE
[RHSSO-2655] making the template probe timeouts match the operator

### DIFF
--- a/templates/passthrough/ocp-3.x/sso76-ocp3-https.json
+++ b/templates/passthrough/ocp-3.x/sso76-ocp3-https.json
@@ -415,7 +415,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -424,7 +428,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql-persistent.json
+++ b/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql-persistent.json
@@ -497,7 +497,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -506,7 +510,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql.json
+++ b/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql.json
@@ -497,7 +497,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -506,7 +510,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/passthrough/ocp-4.x/sso76-ocp4-https.json
+++ b/templates/passthrough/ocp-4.x/sso76-ocp4-https.json
@@ -418,7 +418,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -427,7 +431,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql-persistent.json
+++ b/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql-persistent.json
@@ -501,7 +501,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -510,7 +514,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql.json
+++ b/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql.json
@@ -501,7 +501,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -510,7 +514,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-https.json
+++ b/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-https.json
@@ -269,7 +269,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -278,7 +282,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-postgresql-persistent.json
+++ b/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-postgresql-persistent.json
@@ -450,7 +450,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -459,7 +463,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-https.json
+++ b/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-https.json
@@ -290,7 +290,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -299,7 +303,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {

--- a/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-postgresql-persistent.json
+++ b/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-postgresql-persistent.json
@@ -372,7 +372,11 @@
                                             "/opt/eap/bin/livenessProbe.sh"
                                         ]
                                     },
-                                    "initialDelaySeconds": 60
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 30,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "readinessProbe": {
                                     "exec": {
@@ -381,7 +385,12 @@
                                             "-c",
                                             "/opt/eap/bin/readinessProbe.sh"
                                         ]
-                                    }
+                                    },
+                                    "failureThreshold": 10,
+                                    "initialDelaySeconds": 40,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 22
                                 },
                                 "ports": [
                                     {


### PR DESCRIPTION
Port of https://issues.redhat.com/browse/RHSSO-2655 

The fix for making the probes work with fips adds a significant delay to the probe execution time such that the default of 1 second will no longer work, this matches their timeouts and other settings with what was already in the operator.