### PR TITLE
[RHSSO-2945] Increase default value for the container memory limit in OCP templates

### DIFF
--- a/docs/templates/passthrough/ocp-3.x/sso76-ocp3-https.adoc
+++ b/docs/templates/passthrough/ocp-3.x/sso76-ocp3-https.adoc
@@ -49,7 +49,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE` | `SSO_TRUSTSTORE` | The name of the truststore file within the secret (e.g. truststore.jks) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql-persistent.adoc
+++ b/docs/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql-persistent.adoc
@@ -57,7 +57,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
 |`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 13-el8 | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql.adoc
+++ b/docs/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql.adoc
@@ -56,7 +56,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
 |`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 13-el8 | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/ocp-4.x/sso76-ocp4-https.adoc
+++ b/docs/templates/passthrough/ocp-4.x/sso76-ocp4-https.adoc
@@ -49,7 +49,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE` | `SSO_TRUSTSTORE` | The name of the truststore file within the secret (e.g. truststore.jks) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql-persistent.adoc
+++ b/docs/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql-persistent.adoc
@@ -57,7 +57,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
 |`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 13-el8 | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql.adoc
+++ b/docs/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql.adoc
@@ -56,7 +56,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
 |`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 13-el8 | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/sso76-https.adoc
+++ b/docs/templates/passthrough/sso76-https.adoc
@@ -49,7 +49,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE` | `SSO_TRUSTSTORE` | The name of the truststore file within the secret (e.g. truststore.jks) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/sso76-postgresql-persistent.adoc
+++ b/docs/templates/passthrough/sso76-postgresql-persistent.adoc
@@ -57,7 +57,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
 |`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 13-el8 | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/passthrough/sso76-postgresql.adoc
+++ b/docs/templates/passthrough/sso76-postgresql.adoc
@@ -56,7 +56,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_TRUSTSTORE_PASSWORD` | `SSO_TRUSTSTORE` | The password for the truststore and certificate (e.g. mykeystorepass) | `${SSO_TRUSTSTORE}` | False
 |`SSO_TRUSTSTORE_SECRET` | `SSO_TRUSTSTORE` | The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName | sso-app-secret | False
 |`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream. Typically, this aligns with the major.minor version of PostgreSQL. | 13-el8 | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-https.adoc
+++ b/docs/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-https.adoc
@@ -35,7 +35,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_REALM` | `SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}` | False
 |`SSO_SERVICE_USERNAME` | `SSO_SERVICE_USERNAME` | The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm. | `${SSO_SERVICE_USERNAME}` | False
 |`SSO_SERVICE_PASSWORD` | `SSO_SERVICE_PASSWORD` | The password for the RH-SSO service user. | `${SSO_SERVICE_PASSWORD}` | False
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-postgresql-persistent.adoc
+++ b/docs/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-postgresql-persistent.adoc
@@ -46,7 +46,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`POSTGRESQL_SOURCE_REPOSITORY_URL` | -- | Git source URI for the application extending PostgreSQL SQL server container image with SSL/TLS support. | https://github.com/iankko/redhat-sso-7-openshift-image | True
 |`POSTGRESQL_SOURCE_REPOSITORY_REF` | -- | Git branch/tag reference for the application extending PostgreSQL SQL server container image with SSL/TLS support. | KEYCLOAK-15633 | True
 |`POSTGRESQL_CONTEXT_DIR` | -- | Path within the Git project to build the application extending PostgreSQL SQL server container image with SSL/TLS support. | s2i/postgresql/enable-ssl | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-https.adoc
+++ b/docs/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-https.adoc
@@ -35,7 +35,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_REALM` | `SSO_REALM` | Realm to be created in the RH-SSO server (e.g. demorealm). | `${SSO_REALM}` | False
 |`SSO_SERVICE_USERNAME` | `SSO_SERVICE_USERNAME` | The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm. | `${SSO_SERVICE_USERNAME}` | False
 |`SSO_SERVICE_PASSWORD` | `SSO_SERVICE_PASSWORD` | The password for the RH-SSO service user. | `${SSO_SERVICE_PASSWORD}` | False
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/docs/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-postgresql-persistent.adoc
+++ b/docs/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-postgresql-persistent.adoc
@@ -43,7 +43,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`SSO_SERVICE_USERNAME` | `SSO_SERVICE_USERNAME` | The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm. | `${SSO_SERVICE_USERNAME}` | False
 |`SSO_SERVICE_PASSWORD` | `SSO_SERVICE_PASSWORD` | The password for the RH-SSO service user. | `${SSO_SERVICE_PASSWORD}` | False
 |`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The tag to use for the "postgresql" image stream.  Typically, this aligns with the major.minor version of PostgreSQL. | 13-el8 | True
-|`MEMORY_LIMIT` | -- | Container memory limit. | 1Gi | False
+|`MEMORY_LIMIT` | -- | Container memory limit. | 2Gi | False
 |=======================================================================
 
 

--- a/templates/passthrough/ocp-3.x/sso76-ocp3-https.json
+++ b/templates/passthrough/ocp-3.x/sso76-ocp3-https.json
@@ -207,7 +207,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql-persistent.json
+++ b/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql-persistent.json
@@ -263,7 +263,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql.json
+++ b/templates/passthrough/ocp-3.x/sso76-ocp3-postgresql.json
@@ -256,7 +256,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/passthrough/ocp-4.x/sso76-ocp4-https.json
+++ b/templates/passthrough/ocp-4.x/sso76-ocp4-https.json
@@ -207,7 +207,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql-persistent.json
+++ b/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql-persistent.json
@@ -263,7 +263,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql.json
+++ b/templates/passthrough/ocp-4.x/sso76-ocp4-postgresql.json
@@ -256,7 +256,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-https.json
+++ b/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-https.json
@@ -109,7 +109,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-postgresql-persistent.json
+++ b/templates/reencrypt/ocp-3.x/sso76-ocp3-x509-postgresql-persistent.json
@@ -183,7 +183,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-https.json
+++ b/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-https.json
@@ -109,7 +109,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],

--- a/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-postgresql-persistent.json
+++ b/templates/reencrypt/ocp-4.x/sso76-ocp4-x509-postgresql-persistent.json
@@ -165,7 +165,7 @@
             "displayName": "Container Memory Limit",
             "description": "Container memory limit.",
             "name": "MEMORY_LIMIT",
-            "value": "1Gi",
+            "value": "2Gi",
             "required": false
         }
     ],


### PR DESCRIPTION
RH-SSO OCP templates set a container memory limit to 1GiB, but the JVM options for the container contain `-Xmx1303m`, which means the maximum heap size might be bigger than the memory limit for the whole container. That might cause some unexpected OOM errors.

Conventions and recommendations mention that the allocated part for the heap should be 60%-80% of the whole container memory. As the maximum heap size set by the JVM option is 1303MiB, I propose changing the memory limit to 2GiB instead of 1GiB. 

@vmuzikar @shawkins Could you please check it? Thanks